### PR TITLE
video: required video capability (0xfa) + 0xBEDE RTP extension so sent video renders

### DIFF
--- a/engine.go
+++ b/engine.go
@@ -294,7 +294,7 @@ func (e *engine) onOffer(ev *events.CallOffer) {
 	// Answer/Reject decision. It keeps the offer alive and joins the relay election while
 	// the integrator decides — even a call the user goes on to decline has usually already
 	// been preaccepted.
-	if err := e.sendPreaccept(ev.CallID, ev.From, ev.CallCreator); err != nil {
+	if err := e.sendPreaccept(ev.CallID, ev.From, ev.CallCreator, isVideo); err != nil {
 		e.c.log.Warn().Err(err).Str("call_id", ev.CallID).Msg("preaccept failed")
 	}
 
@@ -307,19 +307,25 @@ func (e *engine) onOffer(ev *events.CallOffer) {
 // eagerly when the offer arrives (see onOffer), independent of the later Answer/Reject
 // decision. Single rate 16000 + encopt + capability, NO metadata — built inline to match
 // the captured WA-Web preaccept body exactly.
-func (e *engine) sendPreaccept(callID string, to, creator types.JID) error {
+func (e *engine) sendPreaccept(callID string, to, creator types.JID, isVideo bool) error {
+	// A video call advertises the <video> decoder here and uses the video capability blob
+	// (0xfa); the audio capability the callee otherwise sends doesn't bring video up.
+	capability := signaling.CapabilityOffer
+	content := []waBinary.Node{
+		{Tag: "audio", Attrs: waBinary.Attrs{"enc": "opus", "rate": "16000"}},
+	}
+	if isVideo {
+		capability = signaling.CapabilityVideoOffer
+		content = append(content, signaling.VideoPreacceptNode())
+	}
+	content = append(content,
+		waBinary.Node{Tag: "encopt", Attrs: waBinary.Attrs{"keygen": "2"}},
+		waBinary.Node{Tag: "capability", Attrs: waBinary.Attrs{"ver": "1"}, Content: capability},
+	)
 	pre := waBinary.Node{
-		Tag:   "call",
-		Attrs: waBinary.Attrs{"to": to, "id": e.c.wa.DangerousInternals().GenerateRequestID()},
-		Content: []waBinary.Node{{
-			Tag:   "preaccept",
-			Attrs: waBinary.Attrs{"call-id": callID, "call-creator": creator},
-			Content: []waBinary.Node{
-				{Tag: "audio", Attrs: waBinary.Attrs{"enc": "opus", "rate": "16000"}},
-				{Tag: "encopt", Attrs: waBinary.Attrs{"keygen": "2"}},
-				{Tag: "capability", Attrs: waBinary.Attrs{"ver": "1"}, Content: signaling.CapabilityOffer},
-			},
-		}},
+		Tag:     "call",
+		Attrs:   waBinary.Attrs{"to": to, "id": e.c.wa.DangerousInternals().GenerateRequestID()},
+		Content: []waBinary.Node{{Tag: "preaccept", Attrs: waBinary.Attrs{"call-id": callID, "call-creator": creator}, Content: content}},
 	}
 	if err := e.c.wa.DangerousInternals().SendNode(context.Background(), pre); err != nil {
 		return fmt.Errorf("send preaccept: %w", err)
@@ -356,12 +362,14 @@ func (e *engine) sendAccept(callID string, to, creator types.JID) {
 		return
 	}
 	m.acceptPending = false
+	isVideo := m.isVideo
 	e.mu.Unlock()
 
 	accept := signaling.BuildAccept(&signaling.AcceptParams{
 		CallID: callID, To: to, CallCreator: creator,
 		AudioRates: []string{"16000"},
 		Metadata:   waBinary.Attrs{"peer_abtest_bucket_id_list": "125208,94276"},
+		Video:      isVideo,
 	})
 	accept.Attrs["id"] = e.c.wa.DangerousInternals().GenerateRequestID()
 	if err := e.c.wa.DangerousInternals().SendNode(context.Background(), accept); err != nil {

--- a/engine_media.go
+++ b/engine_media.go
@@ -354,7 +354,7 @@ func (e *engine) runMedia(ctx context.Context, callID string, call *Call, callKe
 						return fmt.Errorf("relay send binding-success: %w", err)
 					}
 					e.c.diag.Emit("stun", map[string]any{
-						"event": "binding_request_answered",
+						"event":     "binding_request_answered",
 						"tx_id_hex": hex.EncodeToString(tx[:]), "resp_hex": hex.EncodeToString(resp),
 					})
 				}
@@ -455,13 +455,15 @@ const videoRtpStepSamples = 90000 / 15
 //
 // Source of truth: https://github.com/JotaDev66/WaCalls/blob/2d6a1f666426049a89ef9541414e771acdcf8a16/internal/voip/call/callmanager_video.go#L49-L84
 //
-// NOT VALIDATED: the video send media path is unproven.
+// Each packet carries the RFC 5285 0xBEDE header extension (BuildVideoRtpExtension);
+// without it the peer drops the sender's video.
 type videoSender struct {
 	mu      sync.Mutex
 	pipe    *MediaPipeline
 	ch      *relay.RelayMediaChannel
 	ssrc    uint32
 	seq     uint16
+	tccSeq  uint16 // transport-wide-cc sequence, one per packet sent (RTP 0xBEDE ext)
 	ts      uint32
 	started bool
 }
@@ -496,8 +498,13 @@ func (vs *videoSender) send(au []byte) {
 			Timestamp:      vs.ts,
 			Ssrc:           vs.ssrc,
 			Marker:         i == len(payloads)-1,
+			// 0xBEDE header extension (abs-send-time + CVO + transport-cc); the peer
+			// won't render video sent without it.
+			ExtensionProfile: rtp.VideoRtpExtensionProfile,
+			ExtensionData:    rtp.BuildVideoRtpExtension(vs.tccSeq, 0),
 		}
 		vs.seq++
+		vs.tccSeq++
 		pkt, err := vs.pipe.ProtectRTP(&hdr, p)
 		if err != nil {
 			continue

--- a/rtp/rtp.go
+++ b/rtp/rtp.go
@@ -101,19 +101,31 @@ func EstimateSrtpRtpWireBytes(opusPayload []byte) int {
 	return headerSize + len(opusPayload) + tagLen
 }
 
-// RtpHeader is the fixed RTP header plus an optional 0xdebe extension word.
+// RtpHeader is the fixed RTP header plus an optional extension. Audio uses the single
+// 0xdebe WARP extension word (ExtensionWord); video uses the RFC 5285 one-byte 0xBEDE
+// header extension (ExtensionProfile + ExtensionData) — see BuildVideoRtpExtension.
 type RtpHeader struct {
 	Marker         bool
 	PayloadType    uint8
 	SequenceNumber uint16
 	Timestamp      uint32
 	Ssrc           uint32
-	ExtensionWord  *uint32 // nil = no 0xdebe extension word
+	ExtensionWord  *uint32 // nil = no 0xdebe extension word (audio)
+
+	// ExtensionData carries a generic, already 4-byte-aligned RTP header extension
+	// payload (video 0xBEDE). When set, it takes precedence over ExtensionWord and
+	// ExtensionProfile names the extension profile (VideoRtpExtensionProfile).
+	ExtensionProfile uint16
+	ExtensionData    []byte
 }
 
-// ByteSize is the on-wire header size (16, or 20 with an extension word).
+// ByteSize is the on-wire header size: 16 (audio, no word), 20 (audio DTX word), or
+// 12 + 4 + len(ExtensionData) for a generic (video) extension.
 func (h *RtpHeader) ByteSize() int {
 	// Source of truth: https://github.com/oxidezap/whatsapp-rust/blob/41095d4e6ba4610e054e9ede3af1d5e88a83faee/wacore/src/voip/rtp.rs#L93-L99
+	if len(h.ExtensionData) > 0 {
+		return 12 + 4 + len(h.ExtensionData)
+	}
 	if h.ExtensionWord != nil {
 		return WhatsappRtpHeaderDtxSize
 	}
@@ -199,6 +211,19 @@ func EncodeRtpHeader(header *RtpHeader, log ...zerolog.Logger) []byte {
 	buf[3] = byte(header.SequenceNumber)
 	binary.BigEndian.PutUint32(buf[4:8], header.Timestamp)
 	binary.BigEndian.PutUint32(buf[8:12], header.Ssrc)
+	if len(header.ExtensionData) > 0 {
+		// Generic RFC 5285 header extension (video 0xBEDE): profile + 32-bit word count,
+		// followed by the (4-byte-aligned) extension payload.
+		profile := header.ExtensionProfile
+		if profile == 0 {
+			profile = VideoRtpExtensionProfile
+		}
+		binary.BigEndian.PutUint16(buf[12:14], profile)
+		binary.BigEndian.PutUint16(buf[14:16], uint16(len(header.ExtensionData)/4))
+		copy(buf[16:], header.ExtensionData)
+		lg.Trace().Uint32("ssrc", header.Ssrc).Uint16("seq", header.SequenceNumber).Uint16("profile", profile).Int("ext_bytes", len(header.ExtensionData)).Int("header_bytes", size).Msg("encoded rtp header with generic extension")
+		return buf
+	}
 	if size >= 16 {
 		binary.BigEndian.PutUint16(buf[12:14], WhatsappRtpExtensionProfile)
 		var extWords uint16

--- a/rtp/rtp_test.go
+++ b/rtp/rtp_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"os"
+	"reflect"
 	"testing"
 )
 
@@ -79,7 +80,7 @@ func TestParseRoundTripsFixedFields(t *testing.T) {
 		t.Errorf("RtpHeaderByteLength = (%d, %v), want (16, true)", n, ok)
 	}
 	got, ok := ParseRtpHeader(b)
-	if !ok || got != h {
+	if !ok || !reflect.DeepEqual(got, h) {
 		t.Errorf("ParseRtpHeader = (%+v, %v), want (%+v, true)", got, ok, h)
 	}
 }

--- a/rtp/video_ext.go
+++ b/rtp/video_ext.go
@@ -1,0 +1,47 @@
+package rtp
+
+import "time"
+
+// VideoRtpExtensionProfile is the RFC 5285 one-byte header-extension profile (0xBEDE)
+// carried on every outbound H.264 packet, distinct from the audio WARP extension word
+// (WhatsappRtpExtensionProfile, 0xdebe). The peer drops video from senders that omit it;
+// audio is exempt.
+const VideoRtpExtensionProfile uint16 = 0xbede
+
+// Video header-extension element IDs (RFC 5285 one-byte form).
+const (
+	videoExtIDAbsSendTime  = 3 // http://www.webrtc.org/experiments/rtp-hdrext/abs-send-time
+	videoExtIDOrientation  = 5 // urn:3gpp:video-orientation (RFC 7742, CVO)
+	videoExtIDTransportCC  = 6 // http://www.ietf.org/id/draft-holmer-rmcat-transport-wide-cc-extensions
+	videoExtAbsSendTimeLen = 3
+	videoExtOrientationLen = 1
+	videoExtTransportCCLen = 2
+)
+
+// BuildVideoRtpExtension builds the one-byte (RFC 5285) header-extension block carried on
+// every outbound H.264 packet:
+//
+//	id=3 abs-send-time      (3 bytes) — 24-bit 6.18 fixed-point of the wall clock
+//	id=5 video-orientation  (1 byte)  — urn:3gpp:video-orientation (CVO); 0 = upright
+//	id=6 transport-wide-cc  (2 bytes) — per-packet feedback sequence number
+//
+// The elements are zero-padded to a 12-byte (3 × 32-bit word) block. Pair it with
+// VideoRtpExtensionProfile on the RtpHeader and increment tccSeq once per packet sent.
+func BuildVideoRtpExtension(tccSeq uint16, cvo byte) []byte {
+	// abs-send-time: 24-bit unsigned, 6.18 fixed-point of the current wall-clock seconds.
+	secs := float64(time.Now().UnixNano()) / 1e9
+	abs := uint32(secs*262144.0) & 0xffffff
+
+	ext := make([]byte, 12)
+	ext[0] = byte(videoExtIDAbsSendTime<<4) | byte(videoExtAbsSendTimeLen-1) // 0x32
+	ext[1] = byte(abs >> 16)
+	ext[2] = byte(abs >> 8)
+	ext[3] = byte(abs)
+	ext[4] = byte(videoExtIDOrientation<<4) | byte(videoExtOrientationLen-1) // 0x50
+	ext[5] = cvo
+	ext[6] = byte(videoExtIDTransportCC<<4) | byte(videoExtTransportCCLen-1) // 0x61
+	ext[7] = byte(tccSeq >> 8)
+	ext[8] = byte(tccSeq)
+	// ext[9..11] = padding (0x00)
+	return ext
+}

--- a/rtp/video_ext_test.go
+++ b/rtp/video_ext_test.go
@@ -1,0 +1,63 @@
+package rtp
+
+import (
+	"encoding/binary"
+	"testing"
+)
+
+// TestBuildVideoRtpExtensionLayout checks the one-byte (RFC 5285) element layout:
+// abs-send-time (id3,3B) + orientation (id5,1B) + transport-cc (id6,2B), padded to 12B.
+func TestBuildVideoRtpExtensionLayout(t *testing.T) {
+	ext := BuildVideoRtpExtension(0x1234, 2)
+	if len(ext) != 12 {
+		t.Fatalf("ext len = %d, want 12 (3 words)", len(ext))
+	}
+	if ext[0] != 0x32 {
+		t.Errorf("abs-send-time tag = %#x, want 0x32 (id=3,len=3)", ext[0])
+	}
+	if ext[4] != 0x50 {
+		t.Errorf("orientation tag = %#x, want 0x50 (id=5,len=1)", ext[4])
+	}
+	if ext[5] != 2 {
+		t.Errorf("cvo = %d, want 2", ext[5])
+	}
+	if ext[6] != 0x61 {
+		t.Errorf("transport-cc tag = %#x, want 0x61 (id=6,len=2)", ext[6])
+	}
+	if seq := binary.BigEndian.Uint16(ext[7:9]); seq != 0x1234 {
+		t.Errorf("tccSeq = %#x, want 0x1234", seq)
+	}
+}
+
+// TestEncodeVideoExtensionHeader checks that a header carrying ExtensionData encodes the
+// X bit, the 0xBEDE profile, the 32-bit word count, and round-trips its on-wire length.
+func TestEncodeVideoExtensionHeader(t *testing.T) {
+	h := RtpHeader{
+		PayloadType:      RtpPayloadTypeH264,
+		SequenceNumber:   7,
+		Timestamp:        90000,
+		Ssrc:             0x0a0b0c0d,
+		Marker:           true,
+		ExtensionProfile: VideoRtpExtensionProfile,
+		ExtensionData:    BuildVideoRtpExtension(1, 0),
+	}
+	if want := 12 + 4 + 12; h.ByteSize() != want {
+		t.Fatalf("ByteSize = %d, want %d", h.ByteSize(), want)
+	}
+	b := EncodeRtpHeader(&h)
+	if b[0]&0x10 == 0 {
+		t.Error("X (extension) bit not set")
+	}
+	if b[1]&0x7f != RtpPayloadTypeH264 || b[1]&0x80 == 0 {
+		t.Errorf("byte1 = %#x, want PT=97 with marker", b[1])
+	}
+	if prof := binary.BigEndian.Uint16(b[12:14]); prof != VideoRtpExtensionProfile {
+		t.Errorf("ext profile = %#x, want %#x", prof, VideoRtpExtensionProfile)
+	}
+	if words := binary.BigEndian.Uint16(b[14:16]); words != 3 {
+		t.Errorf("ext word count = %d, want 3", words)
+	}
+	if n, ok := RtpHeaderByteLength(b); !ok || n != len(b) {
+		t.Errorf("RtpHeaderByteLength = (%d, %v), want (%d, true)", n, ok, len(b))
+	}
+}

--- a/signaling/stanza.go
+++ b/signaling/stanza.go
@@ -13,8 +13,12 @@ import (
 // is load-bearing (the server returns 439 if it is wrong). Stanza ids generated
 // from random bytes are passed in so the builders stay pure.
 
-// CapabilityOffer is the capability blob for <offer>/<accept> (ver=1).
+// CapabilityOffer is the capability blob for an audio <offer>/<accept> (ver=1).
 var CapabilityOffer = []byte{0x01, 0x05, 0xf7, 0x09, 0xe4, 0xbb, 0x13}
+
+// CapabilityVideoOffer is the capability blob a real client advertises on a video call:
+// byte 6 is 0xfa instead of the audio 0xbb. The callee won't bring up video without it.
+var CapabilityVideoOffer = []byte{0x01, 0x05, 0xf7, 0x09, 0xe4, 0xfa, 0x13}
 
 // CapabilityPreaccept is the capability blob for <preaccept> (ver=1).
 var CapabilityPreaccept = []byte{0x01, 0x05, 0xf7, 0x09, 0xe4, 0xbb, 0x07}

--- a/signaling/video.go
+++ b/signaling/video.go
@@ -55,6 +55,16 @@ func videoAcceptNode() waBinary.Node {
 	return waBinary.Node{Tag: "video", Attrs: waBinary.Attrs{"enc": VideoCodecH264}}
 }
 
+// VideoPreacceptNode builds the <video> advertisement for a <preaccept>: the supported
+// decoder plus the screen geometry, no enc (the callee isn't sending yet).
+// Source of truth: https://github.com/JotaDev66/WaCalls/blob/2d6a1f666426049a89ef9541414e771acdcf8a16/internal/voip/signaling/signaling_build.go#L165-L168
+func VideoPreacceptNode() waBinary.Node {
+	return waBinary.Node{Tag: "video", Attrs: waBinary.Attrs{
+		"dec": "H264", "device_orientation": "0",
+		"screen_width": "1920", "screen_height": "1080",
+	}}
+}
+
 // OfferHasVideo reports whether a parsed <offer> node advertises video — the presence of
 // a <video> child marks an inbound video call.
 func OfferHasVideo(offer *waBinary.Node) bool {

--- a/signaling/video_test.go
+++ b/signaling/video_test.go
@@ -39,6 +39,36 @@ func TestAcceptAdvertisesVideo(t *testing.T) {
 	}
 }
 
+// TestVideoCapabilityByte checks the video capability differs from audio only in byte 6
+// (0xfa vs 0xbb) — the byte a real client flips on a video call.
+func TestVideoCapabilityByte(t *testing.T) {
+	if len(CapabilityVideoOffer) != len(CapabilityOffer) {
+		t.Fatalf("video/audio capability length mismatch: %d vs %d", len(CapabilityVideoOffer), len(CapabilityOffer))
+	}
+	for i := range CapabilityOffer {
+		if i == 5 {
+			continue
+		}
+		if CapabilityVideoOffer[i] != CapabilityOffer[i] {
+			t.Errorf("capability byte %d differs: video=%#x audio=%#x", i, CapabilityVideoOffer[i], CapabilityOffer[i])
+		}
+	}
+	if CapabilityVideoOffer[5] != 0xfa {
+		t.Errorf("video capability byte 6 = %#x, want 0xfa", CapabilityVideoOffer[5])
+	}
+}
+
+// TestVideoPreacceptNode checks the preaccept <video> advertises the H264 decoder.
+func TestVideoPreacceptNode(t *testing.T) {
+	n := VideoPreacceptNode()
+	if n.Tag != "video" {
+		t.Fatalf("tag = %q, want video", n.Tag)
+	}
+	if dec, _ := n.Attrs["dec"].(string); dec != "H264" {
+		t.Errorf("dec = %q, want H264", dec)
+	}
+}
+
 // TestOfferHasVideo checks inbound video detection by <video> child presence.
 func TestOfferHasVideo(t *testing.T) {
 	withVideo := waBinary.Node{Tag: "offer", Content: []waBinary.Node{


### PR DESCRIPTION
While testing the video **send** path against the official WhatsApp clients (Android/iOS), the peer never rendered my video — even though audio and the relay bridge were fine. Comparing my answer-path stanzas and outbound RTP against a capture of a real video call surfaced two missing pieces. With both fixed, the sent camera shows up on the peer.

### 1. The answer path advertised audio, not video

On an inbound video call, the `preaccept`/`accept` were built as if it were an audio call:

- the capability blob was the audio one — `01 05 f7 09 e4 bb 13`. A real client flips **byte 6 to `0xfa`** on a video call (`01 05 f7 09 e4 fa 13`);
- no `<video>` child in the `preaccept` (and none in the `accept` unless explicitly requested).

Without the `0xfa` capability + the `<video>` advertisement the callee doesn't bring video up. This also explains the existing `sendAccept` note that "capability+both-rates fails" — with the audio capability on a video call, it does.

This PR:
- adds `CapabilityVideoOffer` (`…e4 fa 13`) next to the audio `CapabilityOffer`;
- `preaccept`: advertises `<video dec="H264" …>` and uses the video capability when the offer is video;
- `accept`: advertises `<video enc="h264">` when the offer is video (via the existing `AcceptParams.Video`).

### 2. Every sent video packet needs the RFC 5285 `0xBEDE` header extension

The official client carries a one-byte header extension on **every** H.264 RTP packet (profile `0xBEDE`): `abs-send-time` (id 3) + video-orientation/CVO (id 5) + transport-wide-cc seq (id 6). The peer drops video from a sender that omits it; audio is tolerated without it. `videoSender` was sending none.

This PR:
- gives `RtpHeader` a generic extension (`ExtensionProfile` + `ExtensionData`) alongside the existing audio `0xdebe` word, and has `EncodeRtpHeader` emit it;
- adds `BuildVideoRtpExtension(tccSeq, cvo)` for the abs-send-time + CVO + transport-cc block;
- has `videoSender` attach it per packet with a per-packet transport-cc sequence.

### Notes
- The `0xfa` capability byte and the `0xBEDE` extension layout are taken from real video-call captures. The exact stanza wiring mirrors a working sender ([WaCalls](https://github.com/JotaDev66/WaCalls)).
- Tests added for the capability byte, the preaccept `<video>` node, the extension byte layout and the header encoding; `go test ./...` is green and `gofmt` clean.
- Follow-ups I can send separately: pacing the packets (vs. bursting a whole access unit) noticeably speeds how fast the peer locks onto the stream, and stripping AUD (NAL type 9) from the encoder's output since the official client never sends it.
