### PR TITLE
session: derive E2E receive key from the peer's real device (fixes garbled inbound audio)

### DIFF
--- a/session.go
+++ b/session.go
@@ -154,6 +154,12 @@ type MediaPipeline struct {
 	sendRoc      srtp.RocTracker
 	recvRoc      srtp.RecvRocTracker
 	log          zerolog.Logger
+
+	// E2E recv-key auto-selection (see session_recvkey.go): lock onto the peer's
+	// real-device key via WARP MI-tag match instead of the hard-coded device :0.
+	recvCandidates []recvKeyCandidate
+	recvLocked     bool
+	recvTries      int
 }
 
 // NewMediaPipeline derives both directions from the 32-byte callKey: send keys from
@@ -175,11 +181,12 @@ func NewMediaPipeline(callKey []byte, selfJID, peerJID string, ssrc, samplesPerP
 		Uint32("samples_per_packet", samplesPerPacket).Int("warp_mi_tag_len", srtp.WarpMITagLen).
 		Msg("media pipeline initialized")
 	return &MediaPipeline{
-		sendKeys:     sendKeys,
-		recvKeys:     recvKeys,
-		warpMITagLen: srtp.WarpMITagLen,
-		stream:       rtp.NewRtpStream(ssrc, samplesPerPacket, false),
-		log:          log,
+		sendKeys:       sendKeys,
+		recvKeys:       recvKeys,
+		warpMITagLen:   srtp.WarpMITagLen,
+		stream:         rtp.NewRtpStream(ssrc, samplesPerPacket, false),
+		log:            log,
+		recvCandidates: buildRecvKeyCandidates(callKey, peerJID, log),
 	}, nil
 }
 
@@ -240,6 +247,7 @@ func (p *MediaPipeline) UnprotectAudio(packet []byte) (rtp.RtpHeader, []byte, bo
 		return rtp.RtpHeader{}, nil, false
 	}
 	roc := p.recvRoc.GuessRoc(header.SequenceNumber)
+	p.selectRecvKey(withoutTag, packet[len(packet)-p.warpMITagLen:], roc)
 	plain, err := srtp.CryptPayload(&p.recvKeys, header.Ssrc, header.SequenceNumber, roc, withoutTag[headerLen:])
 	if err != nil {
 		p.log.Debug().Err(err).Uint32("ssrc", header.Ssrc).Uint16("seq", header.SequenceNumber).Uint32("roc", roc).Msg("unprotect: SRTP decrypt failed")

--- a/session_recvkey.go
+++ b/session_recvkey.go
@@ -1,0 +1,108 @@
+package meowcaller
+
+import (
+	"crypto/hmac"
+	"strconv"
+	"strings"
+
+	"github.com/rs/zerolog"
+
+	"github.com/purpshell/meowcaller/rtp"
+	"github.com/purpshell/meowcaller/srtp"
+)
+
+// The E2E-SRTP receive key must be derived from the peer's ACTUAL sending device
+// LID ("<user>:<device>@lid"). NewMediaPipeline derives it from
+// FormatE2ESrtpParticipantID(peerJID), and FormatParticipantID forces a bare @lid
+// to device :0 — so whenever the peer streams from a non-zero device the recv
+// key is wrong. Because the payload cipher is AES-CTR (length-preserving) and the
+// WARP MI tag is not verified, a wrong key yields correct-length, high-entropy
+// garbage with no decrypt error, which the (correct) MLow decoder renders as
+// robotic audio. Sending is unaffected: the send key uses our own already
+// device-qualified LID.
+//
+// This picks the right device without new signaling: the WARP MI tag is
+// HMAC-SHA1 over the packet keyed by the sender's per-participant E2E auth key
+// (the same key ProtectAudio signs with), so the peer's real device is the one
+// whose derived recv key reproduces the tag. We derive a candidate key per device
+// index and lock onto the MI-tag match on the first inbound packet.
+//
+// Source of truth (recv key is keyed off the peer's real device, not :0):
+// https://github.com/JotaDev66/WaCalls — re-keys the receive direction from the
+// peer's device-qualified JID (firstPeerDevice / reinitSrtp), yielding clean
+// inbound audio with this same MLow decoder.
+
+// maxRecvDeviceIndex bounds the peer device-index search for the E2E recv key.
+const maxRecvDeviceIndex = 255
+
+// maxRecvSelectPackets caps how many packets we probe before giving up and
+// keeping the default recv key, so a non-matching stream costs bounded work.
+const maxRecvSelectPackets = 250
+
+type recvKeyCandidate struct {
+	id   string
+	keys srtp.E2eSrtpKeys
+}
+
+// buildRecvKeyCandidates derives candidate E2E recv keys across device-qualified
+// peer participant ids, the library default (bare -> :0) first so a correct :0
+// locks immediately.
+func buildRecvKeyCandidates(callKey []byte, peerJID string, log zerolog.Logger) []recvKeyCandidate {
+	var out []recvKeyCandidate
+	seen := make(map[string]bool)
+	add := func(id string) {
+		if id == "" || seen[id] {
+			return
+		}
+		seen[id] = true
+		keys, err := srtp.DeriveE2eKeys(callKey, id)
+		if err != nil {
+			log.Debug().Err(err).Str("participant", id).Msg("recv key candidate: derive failed")
+			return
+		}
+		out = append(out, recvKeyCandidate{id: id, keys: keys})
+	}
+	add(rtp.FormatE2ESrtpParticipantID(peerJID))
+	bare, _, _ := strings.Cut(peerJID, "/")
+	bare = strings.TrimSpace(bare)
+	if at := strings.LastIndexByte(bare, '@'); at > 0 {
+		user := bare[:at]
+		domain := bare[at+1:]
+		base := user
+		if i := strings.IndexByte(user, ':'); i >= 0 {
+			base = user[:i]
+		}
+		if domain == "lid" {
+			for d := 0; d <= maxRecvDeviceIndex; d++ {
+				add(base + ":" + strconv.Itoa(d) + "@" + domain)
+			}
+		}
+	}
+	log.Debug().Int("candidate_count", len(out)).Msg("built e2e recv key candidates")
+	return out
+}
+
+// selectRecvKey locks p.recvKeys onto the candidate whose WARP MI tag matches the
+// packet. No-op once locked; after maxRecvSelectPackets probes it gives up and
+// keeps the default key.
+func (p *MediaPipeline) selectRecvKey(withoutTag, recvTag []byte, roc uint32) {
+	if p.recvLocked {
+		return
+	}
+	for i := range p.recvCandidates {
+		c := &p.recvCandidates[i]
+		if hmac.Equal(srtp.ComputeWarpMITag(c.keys.AuthKey[:], withoutTag, roc, p.warpMITagLen), recvTag) {
+			p.recvKeys = c.keys
+			p.recvLocked = true
+			p.recvCandidates = nil
+			p.log.Info().Str("recv_participant", c.id).Msg("locked e2e recv key via warp mi tag")
+			return
+		}
+	}
+	p.recvTries++
+	if p.recvTries >= maxRecvSelectPackets {
+		p.recvLocked = true
+		p.recvCandidates = nil
+		p.log.Warn().Int("tries", p.recvTries).Msg("no recv key matched warp mi tag; keeping default key")
+	}
+}


### PR DESCRIPTION
## Problem
Inbound 1:1 call audio decodes to garbled/robotic noise, while outbound audio is clean.

## Root cause
`NewMediaPipeline` (`session.go`) derives the E2E-SRTP **receive** key from `rtp.FormatE2ESrtpParticipantID(peerJID)`, and `util.FormatParticipantID` forces a bare `@lid` to device **`:0`**. The peer, however, streams from its real (non-zero) device, so the AES-CTR keystream is wrong. Sending is unaffected because the send key uses our own already-device-qualified LID.

The failure is silent: the payload cipher is AES-CTR (length-preserving) and the WARP MI tag is not verified, so a wrong key produces **correct-length, high-entropy garbage with no decrypt error** — which the (correct) MLow decoder renders as robotic audio.

## Evidence (via `WithDiagnostics`, on a live 1:1 call)
- **0.00% packet loss** (all RTP sequence numbers contiguous) and **0 decrypt failures** — rules out transport/loss.
- `media_keys_input`: peer keyed at `:0`, self at a real non-zero device (`:78`).
- Decrypted payloads were high-entropy (not valid MLow TOC bytes).
- Deriving the recv key from the peer's **real** device → **clean audio**: the raw decoded PCM goes from ~7 impulsive discontinuities/s (peaks railing at ±1.0) to **0**, with natural speech dynamics.

## Cross-reference
[`JotaDev66/WaCalls`](https://github.com/JotaDev66/WaCalls) (stable, byte-identical MLow decoder) gets clean inbound audio because it re-keys the receive direction from the peer's real device-qualified JID, not a hard-coded `:0`.

## Fix
Pick the peer's real device without new signaling plumbing: the WARP MI tag is HMAC-SHA1 over the packet keyed by the sender's per-participant E2E auth key (the same key `ProtectAudio` signs with), so the peer's device is the one whose derived recv key reproduces the tag. `buildRecvKeyCandidates` derives a candidate recv key per device index (default `:0` first); `selectRecvKey` locks onto the MI-tag match on the first inbound packet and falls back to the default after a bounded number of probes.

Alternatively this could key off the peer's device-qualified JID from the `accept` / relay-participant list (WaCalls' approach) to avoid the candidate search — happy to switch if you'd prefer that shape.

## Testing
- `go build ./...`, `go vet ./...`, and the existing session round-trip KATs (`go test .`) pass.
- Verified end-to-end on a live WhatsApp 1:1 call: previously-garbled inbound audio is now clean.

The same recv-key derivation is present on `meowcaller-leg`, so this applies there too.
