### PR TITLE
fix(engine): allocate on the caller's FNA relay for inbound calls

### DIFF
--- a/engine.go
+++ b/engine.go
@@ -1071,8 +1071,17 @@ func parseRelayData(node *waBinary.Node) *relayData {
 }
 
 // getMediaRelayEndpoint prefers an outbound (non-FNA, auth_token_id≠0) endpoint, else
-// any non-FNA, else the first.
-func getMediaRelayEndpoint(rd *relayData) *relayEndpoint {
+// any non-FNA, else the first. For an inbound call the caller's uplink RTP lands on their
+// FNA-marked relay, so we must allocate on that same relay or the relay never bridges the
+// peer's media (the callee connects but hears nothing).
+func getMediaRelayEndpoint(rd *relayData, inbound bool) *relayEndpoint {
+	if inbound {
+		for i := range rd.endpoints {
+			if e := &rd.endpoints[i]; e.isFNA {
+				return e
+			}
+		}
+	}
 	for i := range rd.endpoints {
 		if e := &rd.endpoints[i]; !e.isFNA && e.authTokenID != 0 {
 			return e

--- a/engine_media.go
+++ b/engine_media.go
@@ -39,6 +39,7 @@ func (e *engine) maybeStartMedia(callID string) {
 	m.cancel = cancel
 	call := m.call
 	callKey, selfLID, peerLID, rd := m.callKey, m.selfLID, m.peerLID, m.relay
+	inbound := m.direction == CallDirectionIncoming
 	e.mu.Unlock()
 
 	if call != nil {
@@ -46,7 +47,7 @@ func (e *engine) maybeStartMedia(callID string) {
 	}
 	e.c.log.Info().Str("call_id", callID).Msg("starting media")
 	go func() {
-		if err := e.runMedia(mctx, callID, call, callKey, selfLID, peerLID, rd); err != nil {
+		if err := e.runMedia(mctx, callID, call, callKey, selfLID, peerLID, rd, inbound); err != nil {
 			e.c.log.Warn().Err(err).Str("call_id", callID).Msg("media ended")
 		}
 	}()
@@ -56,9 +57,9 @@ func (e *engine) maybeStartMedia(callID string) {
 // the channel and the allocate bytes (re-sent by the keepalive).
 //
 // NOT VALIDATED: live-relay only.
-func (e *engine) connectAndAllocate(ctx context.Context, rd *relayData, streamSsrcs [9]uint32) (*relay.RelayMediaChannel, []byte, error) {
+func (e *engine) connectAndAllocate(ctx context.Context, rd *relayData, streamSsrcs [9]uint32, inbound bool) (*relay.RelayMediaChannel, []byte, error) {
 	log := e.c.log
-	ep := getMediaRelayEndpoint(rd)
+	ep := getMediaRelayEndpoint(rd, inbound)
 	if ep == nil || len(ep.addresses) == 0 {
 		return nil, nil, fmt.Errorf("relay has no usable endpoint")
 	}
@@ -134,7 +135,7 @@ func (e *engine) connectAndAllocate(ctx context.Context, rd *relayData, streamSs
 // out with the allocate at t+0, BEFORE any RTP; no STUN binding-requests are ever sent.
 //
 // NOT VALIDATED: live-relay only.
-func (e *engine) runMedia(ctx context.Context, callID string, call *Call, callKey []byte, selfLID, peerLID string, rd *relayData) error {
+func (e *engine) runMedia(ctx context.Context, callID string, call *Call, callKey []byte, selfLID, peerLID string, rd *relayData, inbound bool) error {
 	log := e.c.log
 	selfParticipantID := rtp.FormatE2ESrtpParticipantID(selfLID)
 	ssrc, err := rtp.DeriveWasmParticipantSsrc(callID, selfParticipantID, 0, log)
@@ -149,7 +150,7 @@ func (e *engine) runMedia(ctx context.Context, callID string, call *Call, callKe
 	if err != nil {
 		return err
 	}
-	ch, allocate, err := e.connectAndAllocate(ctx, rd, streamSsrcs)
+	ch, allocate, err := e.connectAndAllocate(ctx, rd, streamSsrcs, inbound)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
## Problem

An inbound call's uplink RTP lands on the relay the caller advertised with `is_fna=1` in the offer. `getMediaRelayEndpoint` always selected a non-FNA endpoint, so for **inbound** calls the client allocated on a relay the peer never feeds. The call connects, but no inbound RTP is ever bridged and the callee hears nothing.

Concretely, an offer carries e.g. `frec43c01` (`is_fna=1`), `for2c01`, `gru2c01`. The old logic connected to `for2c01`; the peer's media only ever arrives on `frec43c01`, so `first RTP-classified packet from relay` never fired for inbound calls.

## Fix

Prefer the `is_fna=1` endpoint when the call is inbound. An `inbound` flag is threaded from `maybeStartMedia` (`m.direction == CallDirectionIncoming`) through `runMedia` and `connectAndAllocate` into `getMediaRelayEndpoint`. Outbound selection is unchanged (still non-FNA, `auth_token_id != 0`).

## Testing

- `go build ./...`, `go vet ./...`, `go test ./...` all pass.
- Validated live against WhatsApp: inbound calls now connect to the caller's FNA relay and audio flows both ways; outbound calls unaffected.