### PR TITLE
session: add multi-device SRTP recv key auto-selection for inbound RTP

### DIFF
--- a/client.go
+++ b/client.go
@@ -22,6 +22,8 @@ type Client struct {
 	diag *diag.Recorder
 	eng  *engine
 
+	ringPrimaryOnly bool
+
 	mu             sync.Mutex
 	onIncomingCall func(*Call)
 }
@@ -38,7 +40,7 @@ type CallOptions struct {
 // interception is in place before the receive loop starts.
 func NewClient(wa *whatsmeow.Client, opts ...Option) *Client {
 	cfg := resolveConfig(opts)
-	c := &Client{wa: wa, log: cfg.log, diag: cfg.diag}
+	c := &Client{wa: wa, log: cfg.log, diag: cfg.diag, ringPrimaryOnly: cfg.ringPrimaryOnly}
 	c.eng = newEngine(c)
 	c.eng.install()
 	return c

--- a/client.go
+++ b/client.go
@@ -22,8 +22,6 @@ type Client struct {
 	diag *diag.Recorder
 	eng  *engine
 
-	ringPrimaryOnly bool
-
 	mu             sync.Mutex
 	onIncomingCall func(*Call)
 }
@@ -40,7 +38,7 @@ type CallOptions struct {
 // interception is in place before the receive loop starts.
 func NewClient(wa *whatsmeow.Client, opts ...Option) *Client {
 	cfg := resolveConfig(opts)
-	c := &Client{wa: wa, log: cfg.log, diag: cfg.diag, ringPrimaryOnly: cfg.ringPrimaryOnly}
+	c := &Client{wa: wa, log: cfg.log, diag: cfg.diag}
 	c.eng = newEngine(c)
 	c.eng.install()
 	return c

--- a/engine.go
+++ b/engine.go
@@ -360,6 +360,18 @@ func (e *engine) placeCall(ctx context.Context, target string, opts CallOptions)
 	if len(devices) == 0 {
 		return nil, fmt.Errorf("peer %s has no devices (unreachable / not on WhatsApp)", peerLID)
 	}
+	if e.c.ringPrimaryOnly {
+		primaryOnly := make([]types.JID, 0, len(devices))
+		for _, d := range devices {
+			if d.Device == 0 {
+				primaryOnly = append(primaryOnly, d)
+			}
+		}
+		if len(primaryOnly) > 0 {
+			e.c.log.Info().Int("all_devices", len(devices)).Int("primary_devices", len(primaryOnly)).Msg("ringing peer's primary device only")
+			devices = primaryOnly
+		}
+	}
 
 	var callKey [32]byte
 	if _, err := rand.Read(callKey[:]); err != nil {

--- a/engine.go
+++ b/engine.go
@@ -360,19 +360,6 @@ func (e *engine) placeCall(ctx context.Context, target string, opts CallOptions)
 	if len(devices) == 0 {
 		return nil, fmt.Errorf("peer %s has no devices (unreachable / not on WhatsApp)", peerLID)
 	}
-	if e.c.ringPrimaryOnly {
-		primaryOnly := make([]types.JID, 0, len(devices))
-		for _, d := range devices {
-			if d.Device == 0 {
-				primaryOnly = append(primaryOnly, d)
-			}
-		}
-		if len(primaryOnly) > 0 {
-			e.c.log.Info().Int("all_devices", len(devices)).Int("primary_devices", len(primaryOnly)).Msg("ringing peer's primary device only")
-			devices = primaryOnly
-		}
-	}
-
 	var callKey [32]byte
 	if _, err := rand.Read(callKey[:]); err != nil {
 		return nil, err

--- a/logging.go
+++ b/logging.go
@@ -10,9 +10,8 @@ import (
 type Option func(*config)
 
 type config struct {
-	log             zerolog.Logger
-	diag            *diag.Recorder
-	ringPrimaryOnly bool
+	log  zerolog.Logger
+	diag *diag.Recorder
 }
 
 func resolveConfig(opts []Option) config {
@@ -39,11 +38,3 @@ func WithDiagnostics(rec *diag.Recorder) Option {
 	return func(c *config) { c.diag = rec }
 }
 
-// WithPrimaryDeviceOnly makes outbound calls ring only the peer's primary device
-// (device 0), like a normal 1:1 call, instead of offering to every registered companion
-// device. Offering to all devices forks the media across legs and the relay bridges
-// inbound RTP inconsistently for multi-device peers (the call rings everywhere but the
-// callee's audio may never arrive). Off by default.
-func WithPrimaryDeviceOnly() Option {
-	return func(c *config) { c.ringPrimaryOnly = true }
-}

--- a/logging.go
+++ b/logging.go
@@ -10,8 +10,9 @@ import (
 type Option func(*config)
 
 type config struct {
-	log  zerolog.Logger
-	diag *diag.Recorder
+	log             zerolog.Logger
+	diag            *diag.Recorder
+	ringPrimaryOnly bool
 }
 
 func resolveConfig(opts []Option) config {
@@ -36,4 +37,13 @@ func WithLogger(l zerolog.Logger) Option {
 // diag emit is a no-op at zero cost.
 func WithDiagnostics(rec *diag.Recorder) Option {
 	return func(c *config) { c.diag = rec }
+}
+
+// WithPrimaryDeviceOnly makes outbound calls ring only the peer's primary device
+// (device 0), like a normal 1:1 call, instead of offering to every registered companion
+// device. Offering to all devices forks the media across legs and the relay bridges
+// inbound RTP inconsistently for multi-device peers (the call rings everywhere but the
+// callee's audio may never arrive). Off by default.
+func WithPrimaryDeviceOnly() Option {
+	return func(c *config) { c.ringPrimaryOnly = true }
 }

--- a/session.go
+++ b/session.go
@@ -1,6 +1,7 @@
 package meowcaller
 
 import (
+	"sync"
 	"sync/atomic"
 
 	"github.com/rs/zerolog"
@@ -154,6 +155,7 @@ type MediaPipeline struct {
 	warpMITagLen int
 	stream       *rtp.RtpStream
 	sendRoc      srtp.RocTracker
+	recvMu       sync.Mutex
 	recvRoc      srtp.RecvRocTracker
 	packetsSent  atomic.Uint32
 	octetsSent   atomic.Uint32
@@ -172,10 +174,12 @@ func (p *MediaPipeline) RekeyRecv(callKey []byte, peerJID string) error {
 	if err != nil {
 		return err
 	}
+	p.recvMu.Lock()
 	p.recvKeys = recvKeys
 	p.recvRoc = srtp.RecvRocTracker{}
 	p.recvLocked = true
 	p.recvCandidates = nil
+	p.recvMu.Unlock()
 	return nil
 }
 
@@ -279,9 +283,11 @@ func (p *MediaPipeline) UnprotectAudio(packet []byte) (rtp.RtpHeader, []byte, bo
 		p.log.Debug().Uint32("ssrc", header.Ssrc).Int("header_bytes", headerLen).Msg("unprotect: header length invalid or no payload")
 		return rtp.RtpHeader{}, nil, false
 	}
+	p.recvMu.Lock()
 	roc := p.recvRoc.GuessRoc(header.SequenceNumber)
 	p.selectRecvKey(withoutTag, packet[len(packet)-p.warpMITagLen:], roc)
 	plain, err := srtp.CryptPayload(&p.recvKeys, header.Ssrc, header.SequenceNumber, roc, withoutTag[headerLen:])
+	p.recvMu.Unlock()
 	if err != nil {
 		p.log.Debug().Err(err).Uint32("ssrc", header.Ssrc).Uint16("seq", header.SequenceNumber).Uint32("roc", roc).Msg("unprotect: SRTP decrypt failed")
 		return rtp.RtpHeader{}, nil, false

--- a/session.go
+++ b/session.go
@@ -284,8 +284,11 @@ func (p *MediaPipeline) UnprotectAudio(packet []byte) (rtp.RtpHeader, []byte, bo
 		return rtp.RtpHeader{}, nil, false
 	}
 	p.recvMu.Lock()
-	roc := p.recvRoc.GuessRoc(header.SequenceNumber)
-	p.selectRecvKey(withoutTag, packet[len(packet)-p.warpMITagLen:], roc)
+	nextRecvRoc := p.recvRoc
+	roc := nextRecvRoc.GuessRoc(header.SequenceNumber)
+	if p.selectRecvKey(withoutTag, packet[len(packet)-p.warpMITagLen:], roc) {
+		p.recvRoc = nextRecvRoc
+	}
 	plain, err := srtp.CryptPayload(&p.recvKeys, header.Ssrc, header.SequenceNumber, roc, withoutTag[headerLen:])
 	p.recvMu.Unlock()
 	if err != nil {

--- a/session.go
+++ b/session.go
@@ -1,7 +1,6 @@
 package meowcaller
 
 import (
-	"sync"
 	"sync/atomic"
 
 	"github.com/rs/zerolog"
@@ -155,12 +154,15 @@ type MediaPipeline struct {
 	warpMITagLen int
 	stream       *rtp.RtpStream
 	sendRoc      srtp.RocTracker
-	recvMu       sync.Mutex
 	recvRoc      srtp.RecvRocTracker
 	packetsSent  atomic.Uint32
 	octetsSent   atomic.Uint32
 	rtpTimestamp atomic.Uint32
 	log          zerolog.Logger
+
+	recvCandidates []recvKeyCandidate
+	recvLocked     bool
+	recvTries      int
 }
 
 // RekeyRecv switches the receive keystream to the companion device that answered an
@@ -170,10 +172,10 @@ func (p *MediaPipeline) RekeyRecv(callKey []byte, peerJID string) error {
 	if err != nil {
 		return err
 	}
-	p.recvMu.Lock()
 	p.recvKeys = recvKeys
 	p.recvRoc = srtp.RecvRocTracker{}
-	p.recvMu.Unlock()
+	p.recvLocked = true
+	p.recvCandidates = nil
 	return nil
 }
 
@@ -196,11 +198,12 @@ func NewMediaPipeline(callKey []byte, selfJID, peerJID string, ssrc, samplesPerP
 		Uint32("samples_per_packet", samplesPerPacket).Int("warp_mi_tag_len", srtp.WarpMITagLen).
 		Msg("media pipeline initialized")
 	return &MediaPipeline{
-		sendKeys:     sendKeys,
-		recvKeys:     recvKeys,
-		warpMITagLen: srtp.WarpMITagLen,
-		stream:       rtp.NewRtpStream(ssrc, samplesPerPacket, false),
-		log:          log,
+		sendKeys:       sendKeys,
+		recvKeys:       recvKeys,
+		warpMITagLen:   srtp.WarpMITagLen,
+		stream:         rtp.NewRtpStream(ssrc, samplesPerPacket, false),
+		log:            log,
+		recvCandidates: buildRecvKeyCandidates(callKey, peerJID, log),
 	}, nil
 }
 
@@ -276,10 +279,9 @@ func (p *MediaPipeline) UnprotectAudio(packet []byte) (rtp.RtpHeader, []byte, bo
 		p.log.Debug().Uint32("ssrc", header.Ssrc).Int("header_bytes", headerLen).Msg("unprotect: header length invalid or no payload")
 		return rtp.RtpHeader{}, nil, false
 	}
-	p.recvMu.Lock()
 	roc := p.recvRoc.GuessRoc(header.SequenceNumber)
+	p.selectRecvKey(withoutTag, packet[len(packet)-p.warpMITagLen:], roc)
 	plain, err := srtp.CryptPayload(&p.recvKeys, header.Ssrc, header.SequenceNumber, roc, withoutTag[headerLen:])
-	p.recvMu.Unlock()
 	if err != nil {
 		p.log.Debug().Err(err).Uint32("ssrc", header.Ssrc).Uint16("seq", header.SequenceNumber).Uint32("roc", roc).Msg("unprotect: SRTP decrypt failed")
 		return rtp.RtpHeader{}, nil, false

--- a/session_recvkey.go
+++ b/session_recvkey.go
@@ -61,9 +61,9 @@ func buildRecvKeyCandidates(callKey []byte, peerJID string, log zerolog.Logger) 
 // selectRecvKey locks p.recvKeys onto the candidate whose WARP MI tag matches the
 // packet. No-op once locked; after maxRecvSelectPackets probes it gives up and
 // keeps the default key.
-func (p *MediaPipeline) selectRecvKey(withoutTag, recvTag []byte, roc uint32) {
+func (p *MediaPipeline) selectRecvKey(withoutTag, recvTag []byte, roc uint32) bool {
 	if p.recvLocked {
-		return
+		return true
 	}
 	for i := range p.recvCandidates {
 		c := &p.recvCandidates[i]
@@ -72,7 +72,7 @@ func (p *MediaPipeline) selectRecvKey(withoutTag, recvTag []byte, roc uint32) {
 			p.recvLocked = true
 			p.recvCandidates = nil
 			p.log.Info().Str("recv_participant", c.id).Msg("locked e2e recv key via warp mi tag")
-			return
+			return true
 		}
 	}
 	p.recvTries++
@@ -81,4 +81,5 @@ func (p *MediaPipeline) selectRecvKey(withoutTag, recvTag []byte, roc uint32) {
 		p.recvCandidates = nil
 		p.log.Warn().Int("tries", p.recvTries).Msg("no recv key matched warp mi tag; keeping default key")
 	}
+	return false
 }

--- a/session_recvkey.go
+++ b/session_recvkey.go
@@ -1,0 +1,84 @@
+package meowcaller
+
+import (
+	"crypto/hmac"
+	"strconv"
+	"strings"
+
+	"github.com/rs/zerolog"
+
+	"github.com/purpshell/meowcaller/rtp"
+	"github.com/purpshell/meowcaller/srtp"
+)
+
+const maxRecvDeviceIndex = 255
+const maxRecvSelectPackets = 250
+
+type recvKeyCandidate struct {
+	id   string
+	keys srtp.E2eSrtpKeys
+}
+
+// buildRecvKeyCandidates derives candidate E2E recv keys across device-qualified
+// peer participant IDs. The default (bare -> :0) is first so a correct :0 locks
+// immediately. All device indices 0..255 are tried to handle inbound RTP from an
+// unknown companion device.
+func buildRecvKeyCandidates(callKey []byte, peerJID string, log zerolog.Logger) []recvKeyCandidate {
+	var out []recvKeyCandidate
+	seen := make(map[string]bool)
+	add := func(id string) {
+		if id == "" || seen[id] {
+			return
+		}
+		seen[id] = true
+		keys, err := srtp.DeriveE2eKeys(callKey, id)
+		if err != nil {
+			log.Debug().Err(err).Str("participant", id).Msg("recv key candidate: derive failed")
+			return
+		}
+		out = append(out, recvKeyCandidate{id: id, keys: keys})
+	}
+	add(rtp.FormatE2ESrtpParticipantID(peerJID))
+	bare, _, _ := strings.Cut(peerJID, "/")
+	bare = strings.TrimSpace(bare)
+	if at := strings.LastIndexByte(bare, '@'); at > 0 {
+		user := bare[:at]
+		domain := bare[at+1:]
+		base := user
+		if i := strings.IndexByte(user, ':'); i >= 0 {
+			base = user[:i]
+		}
+		if domain == "lid" {
+			for d := 0; d <= maxRecvDeviceIndex; d++ {
+				add(base + ":" + strconv.Itoa(d) + "@" + domain)
+			}
+		}
+	}
+	log.Debug().Int("candidate_count", len(out)).Msg("built e2e recv key candidates")
+	return out
+}
+
+// selectRecvKey locks p.recvKeys onto the candidate whose WARP MI tag matches the
+// packet. No-op once locked; after maxRecvSelectPackets probes it gives up and
+// keeps the default key.
+func (p *MediaPipeline) selectRecvKey(withoutTag, recvTag []byte, roc uint32) {
+	if p.recvLocked {
+		return
+	}
+	for i := range p.recvCandidates {
+		c := &p.recvCandidates[i]
+		if hmac.Equal(srtp.ComputeWarpMITag(c.keys.AuthKey[:], withoutTag, roc, p.warpMITagLen), recvTag) {
+			p.recvKeys = c.keys
+			p.recvLocked = true
+			p.recvCandidates = nil
+			p.log.Info().Str("recv_participant", c.id).Msg("locked e2e recv key via warp mi tag")
+			return
+		}
+	}
+	p.recvTries++
+	if p.recvTries >= maxRecvSelectPackets {
+		p.recvLocked = true
+		p.recvCandidates = nil
+		p.log.Warn().Int("tries", p.recvTries).Msg("no recv key matched warp mi tag; keeping default key")
+	}
+}

--- a/session_test.go
+++ b/session_test.go
@@ -222,6 +222,54 @@ func TestMediaPipelineMultiCandidateAutoSelect(t *testing.T) {
 	}
 }
 
+func TestRecvKeySelectionSurvivesBadPacketAtSeq65535(t *testing.T) {
+	callKey := iota32()
+	self := "111111111111111:0@lid"
+	initialPeer := "222222222222222:0@lid"
+	answeringPeer := "222222222222222:7@lid"
+	const ssrc = 0x55667788
+
+	receiver, err := NewMediaPipeline(callKey, self, initialPeer, ssrc, FrameSamples)
+	if err != nil {
+		t.Fatalf("receiver: %v", err)
+	}
+	answeringDevice, err := NewMediaPipeline(callKey, answeringPeer, self, ssrc, FrameSamples)
+	if err != nil {
+		t.Fatalf("answering device: %v", err)
+	}
+
+	wrongKeys, _ := srtp.DeriveE2eKeys(callKey, "nobody@lid")
+	badHdr := rtp.RtpHeader{
+		SequenceNumber: 0xFFFF, Ssrc: ssrc, PayloadType: 120, Timestamp: 0,
+	}
+	badBody := rtp.EncodeRtpHeader(&badHdr)
+	badBody = append(badBody, 0xFF, 0xFE)
+	badTag := srtp.ComputeWarpMITag(wrongKeys.AuthKey[:], badBody, 0, srtp.WarpMITagLen)
+	badPkt := append(badBody, badTag...)
+
+	receiver.UnprotectAudio(badPkt)
+	if receiver.recvLocked {
+		t.Fatal("bad-tag packet at seq=65535 locked a key; expected no match")
+	}
+
+	payload := []byte{1, 2, 3, 4, 5}
+	validPkt, err := answeringDevice.ProtectAudio(payload)
+	if err != nil {
+		t.Fatalf("answering device protect: %v", err)
+	}
+
+	_, got, ok := receiver.UnprotectAudio(validPkt)
+	if !ok {
+		t.Fatal("valid :7@lid packet rejected after bad-tag packet at seq=65535")
+	}
+	if !bytes.Equal(got, payload) {
+		t.Fatalf("payload = %x, want %x", got, payload)
+	}
+	if !receiver.recvLocked {
+		t.Fatal("recv key not locked after matching valid packet")
+	}
+}
+
 func TestMediaPipelineTracksSenderStats(t *testing.T) {
 	pipe, err := NewMediaPipeline(iota32(), "111111111111111:0@lid", "222222222222222:0@lid", 0x12345678, 960)
 	if err != nil {

--- a/session_test.go
+++ b/session_test.go
@@ -186,6 +186,42 @@ func TestRecvUsesPeerLidForRecv(t *testing.T) {
 	}
 }
 
+// TestMediaPipelineMultiCandidateAutoSelect proves the candidate system auto-selects
+// the correct recv key for a non-default device without an explicit RekeyRecv call.
+func TestMediaPipelineMultiCandidateAutoSelect(t *testing.T) {
+	callKey := iota32()
+	self := "111111111111111:0@lid"
+	initialPeer := "222222222222222:0@lid"
+	answeringPeer := "222222222222222:7@lid"
+	const ssrc = 0x55667788
+
+	receiver, err := NewMediaPipeline(callKey, self, initialPeer, ssrc, FrameSamples)
+	if err != nil {
+		t.Fatalf("receiver: %v", err)
+	}
+	answeringDevice, err := NewMediaPipeline(callKey, answeringPeer, self, ssrc, FrameSamples)
+	if err != nil {
+		t.Fatalf("answering device: %v", err)
+	}
+
+	payload := []byte{1, 2, 3, 4, 5, 6, 7, 8}
+	packet, err := answeringDevice.ProtectAudio(payload)
+	if err != nil {
+		t.Fatalf("protect: %v", err)
+	}
+
+	_, got, ok := receiver.UnprotectAudio(packet)
+	if !ok {
+		t.Fatal("auto-candidate selection failed: answering-device packet rejected")
+	}
+	if !bytes.Equal(got, payload) {
+		t.Fatalf("auto-candidate payload = %x, want %x", got, payload)
+	}
+	if !receiver.recvLocked {
+		t.Fatal("auto-candidate selection did not lock a key")
+	}
+}
+
 func TestMediaPipelineTracksSenderStats(t *testing.T) {
 	pipe, err := NewMediaPipeline(iota32(), "111111111111111:0@lid", "222222222222222:0@lid", 0x12345678, 960)
 	if err != nil {


### PR DESCRIPTION
### Problem
When receiving an inbound call from a peer with multiple WhatsApp companion devices, the relay may route inbound RTP audio packets from a non-primary device (e.g., `222222222222222:7@lid` instead of `222222222222222:0@lid`). The library derives SRTP receive keys using `rtp.FormatE2ESrtpParticipantID(peerLID)` which resolves to the bare LID with implicit `:0`. Because current main strips but does not verify the WARP MI tag, decrypting packets with a different device's key produces decrypted garbage rather than an authentication failure — the call connects, but no clear audio is heard.

### Root Cause
`engine_media.go:mediaLoop()` derives a single `MediaPipeline` using the peer's LID (implicit device `:0`). `session.go:NewMediaPipeline()` calls `srtp.DeriveE2eKeys()` with this participant ID to produce one SRTP receive key set. When the peer's relay sends RTP with a device-qualified participant ID (e.g., `:7`), the WARP MI tag computed with `:0` keys doesn't match, and `UnprotectAudio()` returns `ok=false`. No key rotation or alternative key trial is attempted.

The upstream's `rekeyPeer` mechanism only works for outgoing calls where a companion device explicitly answers — it does not handle the inbound case where the caller's device identity is unknown.

### Fixes
1. Derive candidate SRTP receive keys for all possible device indices (`:0` through `:255`) using `srtp.DeriveE2eKeys()` for each qualified participant ID.
2. On each inbound packet, attempt WARP MI tag authentication against candidates; lock onto the first matching key.

#### Unit Tests
- `TestMediaPipelineMultiCandidateAutoSelect` (new) — creates a `MediaPipeline` initialized with peer `:0@lid`, encrypts a packet using `:7@lid` keys (simulating a companion device), and verifies `UnprotectAudio()` succeeds via auto-candidate key selection without any explicit `RekeyRecv()` call. Asserts `recvLocked` is set after the match.
- `TestMediaPipelineRekeysReceivePathForAnsweringDevice` (existing) — re-verified that `RekeyRecv()` backward compat is preserved.
- `TestMediaPipelineRoundTrips` (existing) — baseline protect→unprotect with `:0@lid`; no regression for the single-device path.
- `TestRecvUsesPeerLidForRecv` (existing) — verifies wrong-keyed packets are still rejected after candidate system.
- `TestRecvKeySelectionSurvivesBadPacketAtSeq65535` (NEW) — verifies that receiving an unauthenticated packet at sequence number 65535 does not corrupt the ROC tracker and block legitimate key selection for subsequent valid packets.

#### Sequence for Regression Test
- Creates a receiver (peer=:0@lid, 256 candidates including :7@lid) and an answeringDevice (sends as :7@lid)
- Builds a forged packet at seq=65535 with wrong auth key (nobody@lid), calls UnprotectAudio => verifies recvLocked stays false
- Builds a valid packet at seq=1 with payload [1,2,3,4,5] from the answering device, calls UnprotectAudio on the same receiver => verifies it returns the correct payload and locks the key

#### Edge Cases Covered
- **First matching packet locks the key** — `selectRecvKey()` runs on every inbound packet; the first packet with a matching WARP MI tag locks the key permanently. Packets before the lock use the default (`:0`) key (original behavior).
- **No match after 250 packets** — `selectRecvKey()` gives up, locks the default key, logs a warning. Call continues degraded but does not hang.
- **Malformed packet** — `selectRecvKey()` is only reached after length/header checks, so it never operates on truncated data.
- **Primary device replies** — default `:0` candidate is first in the list; it matches and locks immediately with zero overhead.