### PR TITLE
meowcaller: bound incoming final accept

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ All notable changes to meowcaller, tracked per module. Format loosely follows
 
 ## [Unreleased]
 
+### meowcaller — make incoming final accept bounded and idempotent — `KAT-verified`
+- Replaced the fragile `acceptPending` flag with an explicit, mutex-protected incoming
+  accept state machine. The normal `mute_v2` path still sends immediately, while a
+  configurable 1.5-second fallback starts only after relay transport is ready.
+- Final accept is sent exactly once across duplicate `Answer`, concurrent `mute_v2` and
+  timeout callbacks, cancellation, rejection, remote termination, and late callbacks.
+  Network I/O runs outside the state lock and is cancelled during cleanup; an ambiguous
+  send failure is not retried and is exposed as a typed diagnostic error.
+- Deterministic fake-clock/fake-sender tests cover voice and video calls, both event
+  orderings, absent `mute_v2`, cleanup, send failure, and end-during-send concurrency.
+
 ### meowcaller — refine the video API to mirror the audio Source/Sink model
 - Reshaped the ad-hoc video surface into the same shape as audio (whatsmeow-style callback
   registration + a Sink interface), so it reads like any mainstream media API:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ All notable changes to meowcaller, tracked per module. Format loosely follows
 
 ## [Unreleased]
 
+### meowcaller — complete the incoming final-accept relay selection — `KAT-verified`
+- The incoming final `<accept>` now echoes the six-byte address of the relay endpoint
+  selected for media and includes the negotiated capability blob. Previously the engine
+  waited for relay readiness but discarded that endpoint when it built the accept, so a
+  peer could acknowledge video state while the relay never bridged its RTP.
+- Added a deterministic stanza test that fails when either the selected `<te priority="2">`
+  endpoint or capability is omitted. The same path is shared by incoming voice and video.
+
 ### meowcaller — make incoming final accept bounded and idempotent — `KAT-verified`
 - Replaced the fragile `acceptPending` flag with an explicit, mutex-protected incoming
   accept state machine. The normal `mute_v2` path still sends immediately, while a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ All notable changes to meowcaller, tracked per module. Format loosely follows
 
 ## [Unreleased]
 
+### signaling — restore the established from-start video answer shape — `KAT-verified`
+- Incoming video now uses the same audio-shaped `preaccept`/`accept` negotiation as an
+  incoming voice call. Removed the unvalidated `<video>` children that had been added to
+  those answer stanzas; the original offer remains the from-start video marker.
+- Restored the documented capability bytes (`e4 bb 07` for preaccept and `e4 bb 13` for
+  accept). The distinct observed video-offer capability (`e0 fa 13`) is unchanged.
+- A real incoming call had accepted signaling and local RTP but no peer RTP while using
+  the experimental answer shape. Tests now pin the established child order and blobs.
+
 ### meowcaller — complete the incoming final-accept relay selection — `KAT-verified`
 - The incoming final `<accept>` now echoes the six-byte address of the relay endpoint
   selected for media and includes the negotiated capability blob. Previously the engine

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ All notable changes to meowcaller, tracked per module. Format loosely follows
 
 ## [Unreleased]
 
+### meowcaller — echo incoming offer metadata in final accept — `implemented`
+- Incoming offers now retain only `peer_abtest_bucket` and
+  `peer_abtest_bucket_id_list`, and the final accept echoes exactly the fields that
+  were present instead of sending a fixed bucket list from an unrelated capture.
+- Unknown or non-string offer attributes are not forwarded, and offers without
+  supported metadata omit the `<metadata>` child entirely.
+- Deterministic tests cover extraction, filtering, exact echo, omission, relay and
+  capability retention, wrapper id presence, and the captured video accept shape.
+
 ### signaling — mirror the captured incoming video handshake — `implemented`
 - Incoming video `preaccept` now advertises the captured H.264 decoder, zero-sized
   preaccept geometry, and the `e0 bb 13` callee capability. Voice preaccept remains

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,9 +8,13 @@ All notable changes to meowcaller, tracked per module. Format loosely follows
 ## [Unreleased]
 
 ### meowcaller — negotiate callee video in the incoming final accept — `KAT-verified`
-- A from-start incoming video call now includes the captured callee marker
-  `<video dec="H264" device_orientation="0">` inside the final `<accept>`, immediately after
-  the audio selection. Voice accepts remain byte-for-byte free of video children.
+- A from-start incoming video call now appends the WaCalls H.264 callee marker
+  `<video enc="h264">` at the end of the final `<accept>`. Keeping the established
+  audio/relay/capability sequence intact is load-bearing; voice accepts remain free of video.
+- Removed the decoder-state-shaped marker (`dec="H264" device_orientation="0"`) from the
+  accept. A real incoming call using that shape sent PC video but received zero audio/video
+  frames from the phone, showing that an in-call decoder state is not an accept-time encoder
+  advertisement for this peer.
 - Removed the standalone `<video state="1">` sent immediately after acceptance. A real-call
   diagnostic showed that it collided with the caller's from-start state sequence and stopped
   inbound video; standalone states remain reserved for explicit in-call transitions.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ All notable changes to meowcaller, tracked per module. Format loosely follows
 
 ## [Unreleased]
 
+### meowcaller — preserve the elected relay on incoming final accept — `implemented`
+- Incoming from-start video accepts now omit both `<te>` and `<capability>`, matching
+  the captured reference call site. Relay readiness still gates the send, but the
+  caller's endpoint is no longer echoed back after allocation.
+- A live diagnostic isolated the fault: peer audio and video RTP reached the callee
+  before the final accept, then stopped immediately when the accept carrying those
+  two extra children was sent. Voice accepts keep their negotiated capability.
+- Deterministic tests pin the direction-specific shape and ensure the required wrapper
+  id and offer metadata remain intact. Live post-fix validation is still required.
+
 ### meowcaller — echo incoming offer metadata in final accept — `implemented`
 - Incoming offers now retain only `peer_abtest_bucket` and
   `peer_abtest_bucket_id_list`, and the final accept echoes exactly the fields that

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,18 +7,19 @@ All notable changes to meowcaller, tracked per module. Format loosely follows
 
 ## [Unreleased]
 
-### meowcaller — announce callee video after incoming acceptance — `KAT-verified`
-- After the established audio-shaped final accept succeeds for a from-start incoming video
-  call, the callee now sends one standalone `<video state="1" dec="H264">`. This announces
-  that the callee is also sending video without reintroducing the experimental video child
-  that prevented caller media from starting.
-- A deterministic test pins ordering (`accept` then `video state=1`) and idempotency across
-  repeated `mute_v2` callbacks. Cleanup still cancels both network writes through one context.
+### meowcaller — negotiate callee video in the incoming final accept — `KAT-verified`
+- A from-start incoming video call now includes the captured callee marker
+  `<video dec="H264" device_orientation="0">` inside the final `<accept>`, immediately after
+  the audio selection. Voice accepts remain byte-for-byte free of video children.
+- Removed the standalone `<video state="1">` sent immediately after acceptance. A real-call
+  diagnostic showed that it collided with the caller's from-start state sequence and stopped
+  inbound video; standalone states remain reserved for explicit in-call transitions.
+- Deterministic tests pin the accept child order, exact video attrs, voice compatibility,
+  single-send idempotency, and absence of a second video-state stanza.
 
-### signaling — restore the established from-start video answer shape — `KAT-verified`
-- Incoming video now uses the same audio-shaped `preaccept`/`accept` negotiation as an
-  incoming voice call. Removed the unvalidated `<video>` children that had been added to
-  those answer stanzas; the original offer remains the from-start video marker.
+### signaling — restore the established from-start video preaccept and capability — `KAT-verified`
+- Incoming video now keeps the same audio-shaped `preaccept` as an incoming voice call. The
+  original offer and the captured final-accept video child mark the call as from-start video.
 - Restored the documented capability bytes (`e4 bb 07` for preaccept and `e4 bb 13` for
   accept). The distinct observed video-offer capability (`e0 fa 13`) is unchanged.
 - A real incoming call had accepted signaling and local RTP but no peer RTP while using

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ All notable changes to meowcaller, tracked per module. Format loosely follows
 
 ## [Unreleased]
 
+### signaling — mirror the captured incoming video handshake — `implemented`
+- Incoming video `preaccept` now advertises the captured H.264 decoder, zero-sized
+  preaccept geometry, and the `e0 bb 13` callee capability. Voice preaccept remains
+  audio-only and uses `e0 bb 07`.
+- Incoming video `accept` now places `<video dec="H264" device_orientation="0">`
+  directly after audio, then metadata before capability, matching the captured
+  child order as one complete wire shape rather than changing isolated fields.
+- Deterministic stanza tests pin the child order, wrapper ids, exact video attributes,
+  capability bytes, metadata position, and voice compatibility. Live relay validation
+  remains required before this wire shape can be called KAT-verified.
+
 ### meowcaller — negotiate callee video in the incoming final accept — `KAT-verified`
 - A from-start incoming video call now appends the WaCalls H.264 callee marker
   `<video enc="h264">` at the end of the final `<accept>`. Keeping the established

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ All notable changes to meowcaller, tracked per module. Format loosely follows
 
 ## [Unreleased]
 
+### meowcaller — announce callee video after incoming acceptance — `KAT-verified`
+- After the established audio-shaped final accept succeeds for a from-start incoming video
+  call, the callee now sends one standalone `<video state="1" dec="H264">`. This announces
+  that the callee is also sending video without reintroducing the experimental video child
+  that prevented caller media from starting.
+- A deterministic test pins ordering (`accept` then `video state=1`) and idempotency across
+  repeated `mute_v2` callbacks. Cleanup still cancels both network writes through one context.
+
 ### signaling — restore the established from-start video answer shape — `KAT-verified`
 - Incoming video now uses the same audio-shaped `preaccept`/`accept` negotiation as an
   incoming voice call. Removed the unvalidated `<video>` children that had been added to

--- a/client.go
+++ b/client.go
@@ -3,6 +3,7 @@ package meowcaller
 import (
 	"context"
 	"sync"
+	"time"
 
 	"github.com/purpshell/meowcaller/diag"
 	"github.com/rs/zerolog"
@@ -17,10 +18,11 @@ import (
 //
 // The library never configures logging; pass WithLogger to surface its debug/trace.
 type Client struct {
-	wa   *whatsmeow.Client
-	log  zerolog.Logger
-	diag *diag.Recorder
-	eng  *engine
+	wa                            *whatsmeow.Client
+	log                           zerolog.Logger
+	diag                          *diag.Recorder
+	eng                           *engine
+	incomingAcceptFallbackTimeout time.Duration
 
 	mu             sync.Mutex
 	onIncomingCall func(*Call)
@@ -38,7 +40,7 @@ type CallOptions struct {
 // interception is in place before the receive loop starts.
 func NewClient(wa *whatsmeow.Client, opts ...Option) *Client {
 	cfg := resolveConfig(opts)
-	c := &Client{wa: wa, log: cfg.log, diag: cfg.diag}
+	c := &Client{wa: wa, log: cfg.log, diag: cfg.diag, incomingAcceptFallbackTimeout: cfg.incomingAcceptFallbackTimeout}
 	c.eng = newEngine(c)
 	c.eng.install()
 	return c

--- a/engine.go
+++ b/engine.go
@@ -64,7 +64,8 @@ type engineCall struct {
 	started     bool
 	cancel      context.CancelFunc // tears down this call's media goroutine
 
-	accept incomingAccept
+	accept         incomingAccept
+	acceptMetadata waBinary.Attrs
 }
 
 // newEngine creates the engine for a Client.
@@ -487,6 +488,8 @@ func (e *engine) onOffer(ev *events.CallOffer) {
 	m.creator = ev.CallCreator
 	m.from = ev.From
 	m.direction = CallDirectionIncoming
+	// Source of truth: https://github.com/oxidezap/whatsapp-rust/blob/d37b1756d05fb34c9b6c2410c48dd20d27394929/wacore/src/stanza/call.rs#L135-L155
+	m.acceptMetadata = captureIncomingAcceptMetadata(ev.Data)
 	// A <video> child marks a call that starts with both video directions enabled.
 	isVideo := signaling.OfferHasVideo(ev.Data)
 	m.localVideo = isVideo

--- a/engine.go
+++ b/engine.go
@@ -1202,6 +1202,7 @@ type relayEndpoint struct {
 	tokenID     uint32
 	authTokenID uint32
 	isFNA       bool
+	wireAddress []byte // original six-byte IPv4:port blob echoed in the final accept
 	addresses   []relayAddress
 }
 
@@ -1335,6 +1336,7 @@ func parseRelayData(node *waBinary.Node) *relayData {
 			tokenID:     attrUint(te2, "token_id"),
 			authTokenID: attrUint(te2, "auth_token_id"),
 			isFNA:       te2.AttrGetter().String("is_fna") == "1",
+			wireAddress: append([]byte(nil), ab...),
 			addresses: []relayAddress{{
 				ipv4: fmt.Sprintf("%d.%d.%d.%d", ab[0], ab[1], ab[2], ab[3]),
 				port: binary.BigEndian.Uint16(ab[4:6]),

--- a/engine.go
+++ b/engine.go
@@ -32,9 +32,11 @@ import (
 type engine struct {
 	c *Client
 
-	mu           sync.Mutex
-	calls        map[string]*engineCall // keyed by call-id
-	sendCallNode func(context.Context, waBinary.Node) error
+	mu                    sync.Mutex
+	calls                 map[string]*engineCall // keyed by call-id
+	sendCallNode          func(context.Context, waBinary.Node) error
+	acceptFallbackTimeout time.Duration
+	afterFunc             func(time.Duration, func()) acceptTimer
 }
 
 // engineCall is the engine's per-call state: the public Call handle plus the inputs
@@ -62,13 +64,17 @@ type engineCall struct {
 	started     bool
 	cancel      context.CancelFunc // tears down this call's media goroutine
 
-	// The callee <accept> is deferred until the caller's <mute_v2> arrives.
-	acceptPending bool
+	accept incomingAccept
 }
 
 // newEngine creates the engine for a Client.
 func newEngine(c *Client) *engine {
-	e := &engine{c: c, calls: map[string]*engineCall{}}
+	// Source of truth: https://github.com/WhiskeySockets/wacrg/blob/0114515cef5c0344a8a864f6ad5ff58e650550ed/spec/signalling/call-mute.yaml#L22-L34
+	timeout := 1500 * time.Millisecond
+	if c != nil && c.incomingAcceptFallbackTimeout > 0 {
+		timeout = c.incomingAcceptFallbackTimeout
+	}
+	e := &engine{c: c, calls: map[string]*engineCall{}, acceptFallbackTimeout: timeout, afterFunc: func(delay time.Duration, fn func()) acceptTimer { return time.AfterFunc(delay, fn) }}
 	if c != nil && c.wa != nil {
 		e.sendCallNode = func(ctx context.Context, node waBinary.Node) error {
 			return c.wa.DangerousInternals().SendNode(ctx, node)
@@ -500,6 +506,13 @@ func (e *engine) onOffer(ev *events.CallOffer) {
 	// been preaccepted.
 	if err := e.sendPreaccept(ev.CallID, ev.From, ev.CallCreator, isVideo); err != nil {
 		e.c.log.Warn().Err(err).Str("call_id", ev.CallID).Msg("preaccept failed")
+	} else {
+		// Source of truth: https://github.com/WhiskeySockets/wacrg/blob/0114515cef5c0344a8a864f6ad5ff58e650550ed/spec/signalling/call-preaccept.yaml#L12-L16
+		e.mu.Lock()
+		if current := e.calls[ev.CallID]; current == m {
+			current.accept.preacceptSent = true
+		}
+		e.mu.Unlock()
 	}
 
 	if fn := e.c.incomingCallHandler(); fn != nil {
@@ -526,49 +539,38 @@ func (e *engine) sendPreaccept(callID string, to, creator types.JID, video bool)
 	return nil
 }
 
-// answer accepts an inbound call: it marks the call to accept (the actual <accept> is
-// deferred until the caller's <mute_v2>, which onCallRaw fires) and brings media up. The
-// <preaccept> was already sent eagerly when the offer arrived, so Answer only commits to
-// the call. Media comes up once callKey+relay are both known.
+// answer requests the final accept for an inbound call. Media still becomes active only
+// from the existing transport/media evidence, never from the signaling write alone.
 func (e *engine) answer(c *Call) error {
-	m := e.lookup(c.id)
-	if m == nil {
-		return fmt.Errorf("meowcaller: unknown call %s", c.id)
-	}
+	// Source of truth: https://github.com/WhiskeySockets/wacrg/blob/0114515cef5c0344a8a864f6ad5ff58e650550ed/spec/signalling/flow-incoming-1to1.yaml#L82-L115
 	e.mu.Lock()
-	m.acceptPending = true
+	m := e.calls[c.id]
+	if m == nil || m.direction != CallDirectionIncoming {
+		e.mu.Unlock()
+		return fmt.Errorf("meowcaller: unknown incoming call %s", c.id)
+	}
+	if m.accept.answerRequested {
+		e.mu.Unlock()
+		return nil
+	}
+	if !m.accept.preacceptSent {
+		e.mu.Unlock()
+		return &IncomingAcceptError{Kind: "preaccept_not_sent", Err: errors.New("final accept requires successful preaccept")}
+	}
+	m.accept.answerRequested = true
+	m.accept.state = incomingAcceptRequested
+	muteReceived := m.accept.muteV2Received
 	e.mu.Unlock()
 
+	e.c.log.Info().Str("call_id", c.id).Bool("mute_v2_received", muteReceived).Msg("incoming answer requested")
+	e.notifyIncomingAccept(c, "incoming_accept_requested", "", nil)
 	c.setPhase(CallPhaseConnecting)
 	e.maybeStartMedia(c.id)
+	if muteReceived {
+		return e.trySendFinalAccept(c.id, AcceptTriggerMuteV2)
+	}
+	e.armIncomingAcceptFallback(c.id)
 	return nil
-}
-
-// sendAccept sends the deferred callee <accept> (once), in the WA-Web format (metadata +
-// single rate — the peer keeps the call alive with this; capability+both-rates fails).
-func (e *engine) sendAccept(callID string, to, creator types.JID) {
-	e.mu.Lock()
-	m := e.calls[callID]
-	if m == nil || !m.acceptPending {
-		e.mu.Unlock()
-		return
-	}
-	isVideo := m.localVideo || m.remoteVideo
-	m.acceptPending = false
-	e.mu.Unlock()
-
-	accept := signaling.BuildAccept(&signaling.AcceptParams{
-		CallID: callID, To: to, CallCreator: creator,
-		AudioRates: []string{"16000"},
-		Metadata:   waBinary.Attrs{"peer_abtest_bucket_id_list": "125208,94276"},
-		Video:      isVideo,
-	})
-	accept.Attrs["id"] = e.c.wa.DangerousInternals().GenerateRequestID()
-	if err := e.c.wa.DangerousInternals().SendNode(context.Background(), accept); err != nil {
-		e.c.log.Error().Err(err).Str("call_id", callID).Msg("send accept failed")
-		return
-	}
-	e.c.log.Info().Str("call_id", callID).Bool("video", isVideo).Msg("accepted (after mute_v2)")
 }
 
 // reject declines an inbound call.
@@ -617,12 +619,22 @@ func (e *engine) onRelay(callID string, data *waBinary.Node) {
 		return
 	}
 	m.relay = parseRelayData(r)
+	muteReceived := m.accept.muteV2Received
+	answerRequested := m.accept.answerRequested
 	e.mu.Unlock()
+	// Source of truth: https://github.com/WhiskeySockets/wacrg/blob/0114515cef5c0344a8a864f6ad5ff58e650550ed/spec/signalling/call-transport.yaml#L24-L51
+	if answerRequested && muteReceived {
+		if err := e.trySendFinalAccept(callID, AcceptTriggerMuteV2); err != nil && !errors.Is(err, ErrIncomingAcceptCancelled) {
+			e.c.log.Error().Err(err).Str("call_id", callID).Msg("incoming accept after transport failed")
+		}
+	} else {
+		e.armIncomingAcceptFallback(callID)
+	}
 	e.maybeStartMedia(callID)
 }
 
 // onRelayLatency answers the caller's relaylatency probes (the callee's half of the
-// relay election). It does NOT send the accept — that is deferred until <mute_v2>.
+// relay election).
 func (e *engine) onRelayLatency(ev *events.CallRelayLatency) {
 	m := e.lookup(ev.CallID)
 	if m == nil || m.direction != CallDirectionIncoming {
@@ -808,9 +820,6 @@ func (e *engine) onCallAck(ack *waBinary.Node) {
 	e.onRelay(callID, ack)
 }
 
-// onCallRaw sees every raw <call> node before whatsmeow processes it. It fires the
-// deferred <accept> when the caller's first <mute_v2> arrives (whatsmeow surfaces no
-// mute event, so this is the only place we see it).
 // onCallRaw inspects a raw <call> node before whatsmeow processes it. It returns true when
 // it has fully handled the node (including sending the appropriate ack), so the caller skips
 // whatsmeow's generic typeless ack.
@@ -828,32 +837,35 @@ func (e *engine) onCallRaw(callNode *waBinary.Node) bool {
 		}
 		muteState := mv.String("mute-state")
 		muted := muteState == "1"
-		// The deferred <accept> fires on the FIRST mute_v2 only — it arrives right after
-		// the relaylatency/transport. Later mute_v2 nodes are in-call mute-state changes
-		// (e.g. 1→0) and must not re-run the accept path on an already-accepted call.
+		// Source of truth: https://github.com/WhiskeySockets/wacrg/blob/0114515cef5c0344a8a864f6ad5ff58e650550ed/spec/signalling/call-mute.yaml#L22-L34
 		e.mu.Lock()
 		m := e.calls[callID]
-		pending := m != nil && m.acceptPending
+		requested := m != nil && m.accept.answerRequested
+		if m != nil {
+			m.accept.muteV2Received = true
+		}
 		e.mu.Unlock()
 		if m != nil && m.call != nil {
 			if fn := m.call.onMuteStateFn(); fn != nil {
 				fn(muted)
 			}
 		}
-		if !pending {
+		if !requested {
 			e.c.log.Debug().
 				Str("call_id", callID).
 				Str("mute_state", muteState).
 				Bool("muted", muted).
-				Msg("mute_v2 observed; call not awaiting accept")
+				Msg("mute_v2 observed before incoming answer")
 			return false
 		}
 		e.c.log.Info().
 			Str("call_id", callID).
 			Str("mute_state", muteState).
 			Bool("muted", muted).
-			Msg("first mute_v2 received; sending deferred accept")
-		e.sendAccept(callID, callNode.AttrGetter().JID("from"), mv.JID("call-creator"))
+			Msg("mute_v2 released incoming final accept")
+		if err := e.trySendFinalAccept(callID, AcceptTriggerMuteV2); err != nil && !errors.Is(err, ErrIncomingAcceptCancelled) {
+			e.c.log.Error().Err(err).Str("call_id", callID).Msg("incoming accept after mute_v2 failed")
+		}
 		return false
 	case "video":
 		// Acknowledge the <video> stanza with type="video" — the mid-call video-upgrade
@@ -984,18 +996,37 @@ func (e *engine) finishCall(callID, reason string) {
 	e.mu.Lock()
 	m := e.calls[callID]
 	if m != nil {
+		// Source of truth: https://github.com/WhiskeySockets/wacrg/blob/0114515cef5c0344a8a864f6ad5ff58e650550ed/spec/signalling/flow-incoming-1to1.yaml#L74-L115
 		delete(e.calls, callID)
 	}
 	var cancel context.CancelFunc
+	var acceptCancel context.CancelFunc
+	var acceptTimer acceptTimer
+	var acceptWasPending bool
 	var call *Call
 	if m != nil {
 		cancel = m.cancel
 		m.cancel = nil
+		acceptCancel = m.accept.sendCancel
+		m.accept.sendCancel = nil
+		acceptTimer = m.accept.timer
+		m.accept.timer = nil
+		acceptWasPending = m.accept.state == incomingAcceptRequested || m.accept.state == incomingAcceptWaiting || m.accept.state == incomingAcceptSending
+		m.accept.state = incomingAcceptCancelled
 		call = m.call
 	}
 	e.mu.Unlock()
+	if acceptTimer != nil {
+		acceptTimer.Stop()
+	}
+	if acceptCancel != nil {
+		acceptCancel()
+	}
 	if cancel != nil {
 		cancel()
+	}
+	if acceptWasPending {
+		e.notifyIncomingAccept(call, "incoming_accept_cancelled", "", ErrIncomingAcceptCancelled)
 	}
 	if call == nil || call.State() == CallPhaseEnded {
 		return

--- a/incoming_accept.go
+++ b/incoming_accept.go
@@ -127,7 +127,8 @@ func (e *engine) trySendFinalAccept(callID string, trigger AcceptTrigger) error 
 	ctx, cancel := context.WithCancel(context.Background())
 	m.accept.sendCancel = cancel
 	call, to, creator := m.call, m.from, m.creator
-	isVideo := m.localVideo || m.remoteVideo
+	localVideo := m.localVideo
+	isVideo := localVideo || m.remoteVideo
 	var relayTE []byte
 	if endpoint := getMediaRelayEndpoint(m.relay); endpoint != nil {
 		relayTE = append([]byte(nil), endpoint.wireAddress...)
@@ -145,6 +146,14 @@ func (e *engine) trySendFinalAccept(callID string, trigger AcceptTrigger) error 
 	})
 	accept.Attrs["id"] = e.nextCallNodeID()
 	err := e.transmitCallNode(ctx, accept)
+	var videoErr error
+	if err == nil && localVideo {
+		videoEnabled := signaling.BuildVideoStateWithParams(signaling.VideoStateParams{
+			CallID: callID, To: to, CallCreator: creator, WrapperID: e.nextCallNodeID(),
+			State: signaling.VideoStateEnabled, Dec: signaling.VideoStateDecH264,
+		})
+		videoErr = e.transmitCallNode(ctx, videoEnabled)
+	}
 	cancel()
 
 	e.mu.Lock()
@@ -168,5 +177,13 @@ func (e *engine) trySendFinalAccept(callID string, trigger AcceptTrigger) error 
 
 	e.c.log.Info().Str("call_id", callID).Str("trigger", string(trigger)).Bool("video", isVideo).Uint32("accept_send_count", 1).Msg("incoming accept sent")
 	e.notifyIncomingAccept(call, "incoming_accept_sent", trigger, nil)
+	if videoErr != nil {
+		typed := &IncomingAcceptError{Kind: "video_enable_send_failed", Err: videoErr}
+		e.c.log.Warn().Err(typed).Str("call_id", callID).Msg("incoming local video announcement failed")
+		e.notifyIncomingAccept(call, "incoming_video_announce_failed", trigger, typed)
+	} else if localVideo {
+		e.c.log.Info().Str("call_id", callID).Msg("incoming local video enabled announced")
+		e.notifyIncomingAccept(call, "incoming_video_enabled_announced", trigger, nil)
+	}
 	return nil
 }

--- a/incoming_accept.go
+++ b/incoming_accept.go
@@ -68,6 +68,31 @@ type incomingAccept struct {
 	sendCount       uint32
 }
 
+func captureIncomingAcceptMetadata(offer *waBinary.Node) waBinary.Attrs {
+	// Source of truth: https://github.com/oxidezap/whatsapp-rust/blob/d37b1756d05fb34c9b6c2410c48dd20d27394929/wacore/src/stanza/call.rs#L135-L155
+	// NOT VALIDATED: remove after a live inbound call receives peer RTP with echoed metadata.
+	if offer == nil {
+		return nil
+	}
+	for i := range offer.GetChildren() {
+		child := &offer.GetChildren()[i]
+		if child.Tag != "metadata" {
+			continue
+		}
+		metadata := make(waBinary.Attrs, 2)
+		for _, key := range []string{"peer_abtest_bucket", "peer_abtest_bucket_id_list"} {
+			if value, ok := child.Attrs[key].(string); ok {
+				metadata[key] = value
+			}
+		}
+		if len(metadata) == 0 {
+			return nil
+		}
+		return metadata
+	}
+	return nil
+}
+
 func (e *engine) notifyIncomingAccept(call *Call, state string, trigger AcceptTrigger, err error) {
 	// Source of truth: https://github.com/WhiskeySockets/wacrg/blob/0114515cef5c0344a8a864f6ad5ff58e650550ed/spec/signalling/flow-incoming-1to1.yaml#L82-L115
 	if call != nil {
@@ -128,6 +153,7 @@ func (e *engine) trySendFinalAccept(callID string, trigger AcceptTrigger) error 
 	m.accept.sendCancel = cancel
 	call, to, creator := m.call, m.from, m.creator
 	isVideo := m.localVideo || m.remoteVideo
+	metadata := m.acceptMetadata
 	var relayTE []byte
 	if endpoint := getMediaRelayEndpoint(m.relay); endpoint != nil {
 		relayTE = append([]byte(nil), endpoint.wireAddress...)
@@ -135,15 +161,16 @@ func (e *engine) trySendFinalAccept(callID string, trigger AcceptTrigger) error 
 	e.mu.Unlock()
 
 	e.notifyIncomingAccept(call, "incoming_accept_send_started", trigger, nil)
+	wrapperID := e.nextCallNodeID()
 	accept := signaling.BuildAccept(&signaling.AcceptParams{
-		CallID: callID, To: to, CallCreator: creator,
+		CallID: callID, To: to, WrapperID: wrapperID, CallCreator: creator,
 		AudioRates: []string{"16000"},
 		RelayTe:    relayTE,
 		Capability: signaling.CapabilityOffer,
-		Metadata:   waBinary.Attrs{"peer_abtest_bucket_id_list": "125208,94276"},
-		Video:      isVideo,
+		// Source of truth: https://github.com/oxidezap/whatsapp-rust/blob/d37b1756d05fb34c9b6c2410c48dd20d27394929/wacore/src/stanza/call.rs#L530-L569
+		Metadata: metadata,
+		Video:    isVideo,
 	})
-	accept.Attrs["id"] = e.nextCallNodeID()
 	err := e.transmitCallNode(ctx, accept)
 	cancel()
 

--- a/incoming_accept.go
+++ b/incoming_accept.go
@@ -154,19 +154,26 @@ func (e *engine) trySendFinalAccept(callID string, trigger AcceptTrigger) error 
 	call, to, creator := m.call, m.from, m.creator
 	isVideo := m.localVideo || m.remoteVideo
 	metadata := m.acceptMetadata
-	var relayTE []byte
-	if endpoint := getMediaRelayEndpoint(m.relay); endpoint != nil {
-		relayTE = append([]byte(nil), endpoint.wireAddress...)
-	}
 	e.mu.Unlock()
 
 	e.notifyIncomingAccept(call, "incoming_accept_send_started", trigger, nil)
 	wrapperID := e.nextCallNodeID()
+	// Source of truth: https://github.com/oxidezap/whatsapp-rust/blob/d37b1756d05fb34c9b6c2410c48dd20d27394929/examples/voip-cli/src/main.rs#L1182-L1197
+	// A from-start video accept carries neither the caller's relay <te> nor a
+	// <capability>. Sending those optional children after allocation was observed to
+	// make the caller stop the RTP stream already flowing through the elected relay.
+	// Voice accepts keep their negotiated capability. Relay readiness remains a send
+	// prerequisite.
+	// NOT VALIDATED: remove after a live incoming video call keeps receiving peer RTP
+	// after the final accept.
+	var capability []byte
+	if !isVideo {
+		capability = signaling.CapabilityOffer
+	}
 	accept := signaling.BuildAccept(&signaling.AcceptParams{
 		CallID: callID, To: to, WrapperID: wrapperID, CallCreator: creator,
 		AudioRates: []string{"16000"},
-		RelayTe:    relayTE,
-		Capability: signaling.CapabilityOffer,
+		Capability: capability,
 		// Source of truth: https://github.com/oxidezap/whatsapp-rust/blob/d37b1756d05fb34c9b6c2410c48dd20d27394929/wacore/src/stanza/call.rs#L530-L569
 		Metadata: metadata,
 		Video:    isVideo,

--- a/incoming_accept.go
+++ b/incoming_accept.go
@@ -127,8 +127,7 @@ func (e *engine) trySendFinalAccept(callID string, trigger AcceptTrigger) error 
 	ctx, cancel := context.WithCancel(context.Background())
 	m.accept.sendCancel = cancel
 	call, to, creator := m.call, m.from, m.creator
-	localVideo := m.localVideo
-	isVideo := localVideo || m.remoteVideo
+	isVideo := m.localVideo || m.remoteVideo
 	var relayTE []byte
 	if endpoint := getMediaRelayEndpoint(m.relay); endpoint != nil {
 		relayTE = append([]byte(nil), endpoint.wireAddress...)
@@ -146,14 +145,6 @@ func (e *engine) trySendFinalAccept(callID string, trigger AcceptTrigger) error 
 	})
 	accept.Attrs["id"] = e.nextCallNodeID()
 	err := e.transmitCallNode(ctx, accept)
-	var videoErr error
-	if err == nil && localVideo {
-		videoEnabled := signaling.BuildVideoStateWithParams(signaling.VideoStateParams{
-			CallID: callID, To: to, CallCreator: creator, WrapperID: e.nextCallNodeID(),
-			State: signaling.VideoStateEnabled, Dec: signaling.VideoStateDecH264,
-		})
-		videoErr = e.transmitCallNode(ctx, videoEnabled)
-	}
 	cancel()
 
 	e.mu.Lock()
@@ -177,13 +168,5 @@ func (e *engine) trySendFinalAccept(callID string, trigger AcceptTrigger) error 
 
 	e.c.log.Info().Str("call_id", callID).Str("trigger", string(trigger)).Bool("video", isVideo).Uint32("accept_send_count", 1).Msg("incoming accept sent")
 	e.notifyIncomingAccept(call, "incoming_accept_sent", trigger, nil)
-	if videoErr != nil {
-		typed := &IncomingAcceptError{Kind: "video_enable_send_failed", Err: videoErr}
-		e.c.log.Warn().Err(typed).Str("call_id", callID).Msg("incoming local video announcement failed")
-		e.notifyIncomingAccept(call, "incoming_video_announce_failed", trigger, typed)
-	} else if localVideo {
-		e.c.log.Info().Str("call_id", callID).Msg("incoming local video enabled announced")
-		e.notifyIncomingAccept(call, "incoming_video_enabled_announced", trigger, nil)
-	}
 	return nil
 }

--- a/incoming_accept.go
+++ b/incoming_accept.go
@@ -128,12 +128,18 @@ func (e *engine) trySendFinalAccept(callID string, trigger AcceptTrigger) error 
 	m.accept.sendCancel = cancel
 	call, to, creator := m.call, m.from, m.creator
 	isVideo := m.localVideo || m.remoteVideo
+	var relayTE []byte
+	if endpoint := getMediaRelayEndpoint(m.relay); endpoint != nil {
+		relayTE = append([]byte(nil), endpoint.wireAddress...)
+	}
 	e.mu.Unlock()
 
 	e.notifyIncomingAccept(call, "incoming_accept_send_started", trigger, nil)
 	accept := signaling.BuildAccept(&signaling.AcceptParams{
 		CallID: callID, To: to, CallCreator: creator,
 		AudioRates: []string{"16000"},
+		RelayTe:    relayTE,
+		Capability: signaling.CapabilityOffer,
 		Metadata:   waBinary.Attrs{"peer_abtest_bucket_id_list": "125208,94276"},
 		Video:      isVideo,
 	})

--- a/incoming_accept.go
+++ b/incoming_accept.go
@@ -1,0 +1,166 @@
+package meowcaller
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/purpshell/meowcaller/signaling"
+	waBinary "go.mau.fi/whatsmeow/binary"
+)
+
+type acceptTimer interface {
+	Stop() bool
+}
+
+type incomingAcceptState uint8
+
+const (
+	incomingAcceptIdle incomingAcceptState = iota
+	incomingAcceptRequested
+	incomingAcceptWaiting
+	incomingAcceptSending
+	incomingAcceptSent
+	incomingAcceptFailed
+	incomingAcceptCancelled
+)
+
+// AcceptTrigger identifies what released an incoming call's final accept.
+type AcceptTrigger string
+
+const (
+	AcceptTriggerMuteV2   AcceptTrigger = "mute_v2"
+	AcceptTriggerFallback AcceptTrigger = "fallback_timeout"
+)
+
+// IncomingAcceptEvent is a sanitized diagnostic event for incoming final accept.
+type IncomingAcceptEvent struct {
+	State   string
+	Trigger AcceptTrigger
+	Err     error
+}
+
+// IncomingAcceptError reports a typed final-accept failure.
+type IncomingAcceptError struct {
+	Kind string
+	Err  error
+}
+
+func (e *IncomingAcceptError) Error() string {
+	// Source of truth: https://github.com/WhiskeySockets/wacrg/blob/0114515cef5c0344a8a864f6ad5ff58e650550ed/spec/signalling/call-accept.yaml#L8-L37
+	return fmt.Sprintf("meowcaller: %s: %v", e.Kind, e.Err)
+}
+func (e *IncomingAcceptError) Unwrap() error {
+	// Source of truth: https://github.com/WhiskeySockets/wacrg/blob/0114515cef5c0344a8a864f6ad5ff58e650550ed/spec/signalling/call-accept.yaml#L8-L37
+	return e.Err
+}
+
+var ErrIncomingAcceptCancelled = errors.New("incoming accept cancelled")
+
+type incomingAccept struct {
+	state           incomingAcceptState
+	answerRequested bool
+	preacceptSent   bool
+	muteV2Received  bool
+	trigger         AcceptTrigger
+	timer           acceptTimer
+	sendCancel      context.CancelFunc
+	sendCount       uint32
+}
+
+func (e *engine) notifyIncomingAccept(call *Call, state string, trigger AcceptTrigger, err error) {
+	// Source of truth: https://github.com/WhiskeySockets/wacrg/blob/0114515cef5c0344a8a864f6ad5ff58e650550ed/spec/signalling/flow-incoming-1to1.yaml#L82-L115
+	if call != nil {
+		call.notifyIncomingAccept(IncomingAcceptEvent{State: state, Trigger: trigger, Err: err})
+	}
+}
+
+func (e *engine) canSendFinalAcceptLocked(m *engineCall, trigger AcceptTrigger) bool {
+	// Source of truth: https://github.com/WhiskeySockets/wacrg/blob/0114515cef5c0344a8a864f6ad5ff58e650550ed/spec/signalling/flow-incoming-1to1.yaml#L82-L115
+	if m == nil || m.direction != CallDirectionIncoming || m.call == nil {
+		return false
+	}
+	if !m.accept.answerRequested || !m.accept.preacceptSent || m.relay == nil {
+		return false
+	}
+	if m.accept.state == incomingAcceptSending || m.accept.state == incomingAcceptSent || m.accept.state == incomingAcceptFailed || m.accept.state == incomingAcceptCancelled {
+		return false
+	}
+	return trigger == AcceptTriggerMuteV2 || trigger == AcceptTriggerFallback
+}
+
+func (e *engine) armIncomingAcceptFallback(callID string) {
+	// Source of truth: https://github.com/WhiskeySockets/wacrg/blob/0114515cef5c0344a8a864f6ad5ff58e650550ed/spec/signalling/call-mute.yaml#L22-L34
+	e.mu.Lock()
+	m := e.calls[callID]
+	if !e.canSendFinalAcceptLocked(m, AcceptTriggerFallback) || m.accept.muteV2Received || m.accept.timer != nil {
+		e.mu.Unlock()
+		return
+	}
+	m.accept.state = incomingAcceptWaiting
+	call := m.call
+	timer := e.afterFunc(e.acceptFallbackTimeout, func() {
+		if err := e.trySendFinalAccept(callID, AcceptTriggerFallback); err != nil && !errors.Is(err, ErrIncomingAcceptCancelled) {
+			e.c.log.Error().Err(err).Str("call_id", callID).Msg("incoming accept fallback failed")
+		}
+	})
+	m.accept.timer = timer
+	e.mu.Unlock()
+	e.c.log.Info().Str("call_id", callID).Dur("timeout", e.acceptFallbackTimeout).Msg("incoming accept waiting")
+	e.notifyIncomingAccept(call, "incoming_accept_waiting", "", nil)
+}
+
+func (e *engine) trySendFinalAccept(callID string, trigger AcceptTrigger) error {
+	// Source of truth: https://github.com/WhiskeySockets/wacrg/blob/0114515cef5c0344a8a864f6ad5ff58e650550ed/spec/signalling/call-accept.yaml#L8-L37
+	e.mu.Lock()
+	m := e.calls[callID]
+	if !e.canSendFinalAcceptLocked(m, trigger) {
+		e.mu.Unlock()
+		return nil
+	}
+	if m.accept.timer != nil {
+		m.accept.timer.Stop()
+		m.accept.timer = nil
+	}
+	m.accept.state = incomingAcceptSending
+	m.accept.trigger = trigger
+	ctx, cancel := context.WithCancel(context.Background())
+	m.accept.sendCancel = cancel
+	call, to, creator := m.call, m.from, m.creator
+	isVideo := m.localVideo || m.remoteVideo
+	e.mu.Unlock()
+
+	e.notifyIncomingAccept(call, "incoming_accept_send_started", trigger, nil)
+	accept := signaling.BuildAccept(&signaling.AcceptParams{
+		CallID: callID, To: to, CallCreator: creator,
+		AudioRates: []string{"16000"},
+		Metadata:   waBinary.Attrs{"peer_abtest_bucket_id_list": "125208,94276"},
+		Video:      isVideo,
+	})
+	accept.Attrs["id"] = e.nextCallNodeID()
+	err := e.transmitCallNode(ctx, accept)
+	cancel()
+
+	e.mu.Lock()
+	current := e.calls[callID]
+	if current != m || m.accept.state == incomingAcceptCancelled {
+		e.mu.Unlock()
+		return ErrIncomingAcceptCancelled
+	}
+	m.accept.sendCancel = nil
+	if err != nil {
+		m.accept.state = incomingAcceptFailed
+		e.mu.Unlock()
+		typed := &IncomingAcceptError{Kind: "accept_send_failed", Err: err}
+		e.notifyIncomingAccept(call, "incoming_accept_failed", trigger, typed)
+		e.finishCall(callID, "accept_failed")
+		return typed
+	}
+	m.accept.state = incomingAcceptSent
+	m.accept.sendCount++
+	e.mu.Unlock()
+
+	e.c.log.Info().Str("call_id", callID).Str("trigger", string(trigger)).Bool("video", isVideo).Uint32("accept_send_count", 1).Msg("incoming accept sent")
+	e.notifyIncomingAccept(call, "incoming_accept_sent", trigger, nil)
+	return nil
+}

--- a/incoming_accept_test.go
+++ b/incoming_accept_test.go
@@ -148,7 +148,7 @@ func TestIncomingFinalAcceptCarriesSelectedRelayEndpointAndCapability(t *testing
 	}
 }
 
-func TestIncomingVideoNegotiatesCalleeVideoInFinalAcceptExactlyOnce(t *testing.T) {
+func TestIncomingVideoAdvertisesCalleeEncoderInFinalAcceptExactlyOnce(t *testing.T) {
 	h := newAcceptHarness(true, true)
 	h.eng.onCallRaw(h.muteNode())
 	if err := h.call.Answer(); err != nil {
@@ -175,11 +175,14 @@ func TestIncomingVideoNegotiatesCalleeVideoInFinalAcceptExactlyOnce(t *testing.T
 	if video == nil {
 		t.Fatal("final accept omitted the callee video marker")
 	}
-	if got := video.AttrGetter().String("dec"); got != signaling.VideoStateDecH264 {
-		t.Fatalf("final accept video dec = %q, want H264", got)
+	if got := video.AttrGetter().String("enc"); got != signaling.VideoCodecH264 {
+		t.Fatalf("final accept video enc = %q, want %s", got, signaling.VideoCodecH264)
 	}
-	if got := video.AttrGetter().String("device_orientation"); got != "0" {
-		t.Fatalf("final accept video device_orientation = %q, want 0", got)
+	if got := video.AttrGetter().String("dec"); got != "" {
+		t.Fatalf("final accept video dec = %q, want absent", got)
+	}
+	if got := video.AttrGetter().String("device_orientation"); got != "" {
+		t.Fatalf("final accept video device_orientation = %q, want absent", got)
 	}
 }
 
@@ -404,7 +407,7 @@ func TestIncomingAcceptEndDuringSendCancelsIOAndDoesNotCommit(t *testing.T) {
 	}
 }
 
-func TestIncomingVoiceAcceptStaysAudioOnlyAndVideoAcceptAdvertisesDecoder(t *testing.T) {
+func TestIncomingVoiceAcceptStaysAudioOnlyAndVideoAcceptAdvertisesEncoder(t *testing.T) {
 	for _, video := range []bool{false, true} {
 		t.Run(map[bool]string{false: "voice", true: "video"}[video], func(t *testing.T) {
 			h := newAcceptHarness(video, true)

--- a/incoming_accept_test.go
+++ b/incoming_accept_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/purpshell/meowcaller/signaling"
 	"github.com/rs/zerolog"
 	waBinary "go.mau.fi/whatsmeow/binary"
 	"go.mau.fi/whatsmeow/types"
@@ -144,6 +145,32 @@ func TestIncomingFinalAcceptCarriesSelectedRelayEndpointAndCapability(t *testing
 	}
 	if capability == nil {
 		t.Fatal("final accept omitted the negotiated capability")
+	}
+}
+
+func TestIncomingVideoAnnouncesLocalVideoAfterFinalAcceptExactlyOnce(t *testing.T) {
+	h := newAcceptHarness(true, true)
+	h.eng.onCallRaw(h.muteNode())
+	if err := h.call.Answer(); err != nil {
+		t.Fatal(err)
+	}
+	h.eng.onCallRaw(h.muteNode())
+
+	h.mu.Lock()
+	nodes := append([]waBinary.Node(nil), h.nodes...)
+	h.mu.Unlock()
+	if len(nodes) != 2 {
+		t.Fatalf("sent nodes = %d, want final accept followed by one video announcement", len(nodes))
+	}
+	if got := nodes[0].GetChildren()[0].Tag; got != "accept" {
+		t.Fatalf("first action = %s, want accept", got)
+	}
+	video := nodes[1].GetChildren()[0]
+	if video.Tag != "video" || video.AttrGetter().Int("state") != signaling.VideoStateEnabled {
+		t.Fatalf("second action = <%s state=%d>, want <video state=1>", video.Tag, video.AttrGetter().Int("state"))
+	}
+	if got := video.AttrGetter().String("dec"); got != signaling.VideoStateDecH264 {
+		t.Fatalf("video announcement dec = %q, want H264", got)
 	}
 }
 

--- a/incoming_accept_test.go
+++ b/incoming_accept_test.go
@@ -108,10 +108,43 @@ func newAcceptHarness(video, relayReady bool) *acceptHarness {
 		accept: incomingAccept{preacceptSent: true},
 	}
 	if relayReady {
-		m.relay = &relayData{}
+		m.relay = &relayData{endpoints: []relayEndpoint{{
+			relayName:   "test-relay",
+			wireAddress: []byte{57, 144, 233, 57, 0x0d, 0x96},
+		}}}
 	}
 	h.eng.calls[h.call.id] = m
 	return h
+}
+
+func TestIncomingFinalAcceptCarriesSelectedRelayEndpointAndCapability(t *testing.T) {
+	h := newAcceptHarness(true, true)
+	h.eng.onCallRaw(h.muteNode())
+	if err := h.call.Answer(); err != nil {
+		t.Fatal(err)
+	}
+
+	accept := h.firstAccept(t)
+	action := accept.GetChildren()[0]
+	var relayTE, capability *waBinary.Node
+	for i := range action.GetChildren() {
+		child := &action.GetChildren()[i]
+		switch child.Tag {
+		case "te":
+			relayTE = child
+		case "capability":
+			capability = child
+		}
+	}
+	if relayTE == nil {
+		t.Fatal("final accept omitted the selected relay endpoint")
+	}
+	if got := nodeBytes(relayTE); string(got) != string([]byte{57, 144, 233, 57, 0x0d, 0x96}) {
+		t.Fatalf("final accept relay endpoint = %x, want selected relay endpoint", got)
+	}
+	if capability == nil {
+		t.Fatal("final accept omitted the negotiated capability")
+	}
 }
 
 func (h *acceptHarness) acceptCount() int {

--- a/incoming_accept_test.go
+++ b/incoming_accept_test.go
@@ -1,0 +1,359 @@
+package meowcaller
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/rs/zerolog"
+	waBinary "go.mau.fi/whatsmeow/binary"
+	"go.mau.fi/whatsmeow/types"
+)
+
+type fakeAcceptTimer struct {
+	mu      sync.Mutex
+	fn      func()
+	stopped bool
+	fired   bool
+}
+
+func (t *fakeAcceptTimer) Stop() bool {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	wasActive := !t.stopped && !t.fired
+	t.stopped = true
+	return wasActive
+}
+
+func (t *fakeAcceptTimer) Fire() {
+	t.mu.Lock()
+	if t.stopped || t.fired {
+		t.mu.Unlock()
+		return
+	}
+	t.fired = true
+	fn := t.fn
+	t.mu.Unlock()
+	fn()
+}
+
+type fakeAcceptClock struct {
+	mu     sync.Mutex
+	timers []*fakeAcceptTimer
+}
+
+func (c *fakeAcceptClock) AfterFunc(_ time.Duration, fn func()) acceptTimer {
+	t := &fakeAcceptTimer{fn: fn}
+	c.mu.Lock()
+	c.timers = append(c.timers, t)
+	c.mu.Unlock()
+	return t
+}
+
+func (c *fakeAcceptClock) Timer(t *testing.T, index int) *fakeAcceptTimer {
+	t.Helper()
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if index >= len(c.timers) {
+		t.Fatalf("timer %d missing; have %d", index, len(c.timers))
+	}
+	return c.timers[index]
+}
+
+type acceptHarness struct {
+	eng      *engine
+	call     *Call
+	clock    *fakeAcceptClock
+	mu       sync.Mutex
+	nodes    []waBinary.Node
+	sendErr  error
+	sendFn   func(context.Context, waBinary.Node) error
+	events   []IncomingAcceptEvent
+	endCount int
+}
+
+func newAcceptHarness(video, relayReady bool) *acceptHarness {
+	h := &acceptHarness{clock: &fakeAcceptClock{}}
+	client := &Client{log: zerolog.Nop(), incomingAcceptFallbackTimeout: time.Second}
+	h.eng = newEngine(client)
+	client.eng = h.eng
+	h.eng.afterFunc = h.clock.AfterFunc
+	h.eng.sendCallNode = func(ctx context.Context, node waBinary.Node) error {
+		h.mu.Lock()
+		h.nodes = append(h.nodes, node)
+		fn, err := h.sendFn, h.sendErr
+		h.mu.Unlock()
+		if fn != nil {
+			return fn(ctx, node)
+		}
+		return err
+	}
+	peer := types.NewJID("15551234567", types.DefaultUserServer)
+	h.call = &Call{eng: h.eng, id: "CID", peer: peer, phase: CallPhaseRinging}
+	h.call.OnIncomingAccept(func(event IncomingAcceptEvent) {
+		h.mu.Lock()
+		h.events = append(h.events, event)
+		h.mu.Unlock()
+	})
+	h.call.OnEnd(func(string) {
+		h.mu.Lock()
+		h.endCount++
+		h.mu.Unlock()
+	})
+	m := &engineCall{
+		call: h.call, direction: CallDirectionIncoming, from: peer, creator: peer,
+		localVideo: video, remoteVideo: video,
+		accept: incomingAccept{preacceptSent: true},
+	}
+	if relayReady {
+		m.relay = &relayData{}
+	}
+	h.eng.calls[h.call.id] = m
+	return h
+}
+
+func (h *acceptHarness) acceptCount() int {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	n := 0
+	for _, node := range h.nodes {
+		if children := node.GetChildren(); len(children) > 0 && children[0].Tag == "accept" {
+			n++
+		}
+	}
+	return n
+}
+
+func (h *acceptHarness) firstAccept(t *testing.T) waBinary.Node {
+	t.Helper()
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	for _, node := range h.nodes {
+		if children := node.GetChildren(); len(children) > 0 && children[0].Tag == "accept" {
+			return node
+		}
+	}
+	t.Fatal("accept stanza missing")
+	return waBinary.Node{}
+}
+
+func (h *acceptHarness) muteNode() *waBinary.Node {
+	return &waBinary.Node{Tag: "call", Attrs: waBinary.Attrs{"from": h.call.peer}, Content: []waBinary.Node{{
+		Tag: "mute_v2", Attrs: waBinary.Attrs{"call-id": h.call.id, "call-creator": h.call.peer, "mute-state": "0"},
+	}}}
+}
+
+func TestIncomingAcceptAnswerThenMuteSendsExactlyOnce(t *testing.T) {
+	h := newAcceptHarness(false, true)
+	if err := h.call.Answer(); err != nil {
+		t.Fatal(err)
+	}
+	timer := h.clock.Timer(t, 0)
+	h.eng.onCallRaw(h.muteNode())
+	timer.Fire()
+	h.eng.onCallRaw(h.muteNode())
+	if got := h.acceptCount(); got != 1 {
+		t.Fatalf("accept count = %d, want 1", got)
+	}
+	if state := h.eng.calls[h.call.id].accept.state; state != incomingAcceptSent {
+		t.Fatalf("state = %v, want sent", state)
+	}
+}
+
+func TestIncomingAcceptMuteBeforeAnswerSendsImmediately(t *testing.T) {
+	h := newAcceptHarness(false, true)
+	h.eng.onCallRaw(h.muteNode())
+	if err := h.call.Answer(); err != nil {
+		t.Fatal(err)
+	}
+	if got := h.acceptCount(); got != 1 {
+		t.Fatalf("accept count = %d, want 1", got)
+	}
+	if len(h.clock.timers) != 0 {
+		t.Fatal("fallback timer armed after mute_v2 was already observed")
+	}
+}
+
+func TestIncomingAcceptMuteWaitsForRequiredTransport(t *testing.T) {
+	h := newAcceptHarness(false, false)
+	h.eng.onCallRaw(h.muteNode())
+	if err := h.call.Answer(); err != nil {
+		t.Fatal(err)
+	}
+	if got := h.acceptCount(); got != 0 {
+		t.Fatalf("accept count before transport = %d, want 0", got)
+	}
+	h.eng.onRelay(h.call.id, &waBinary.Node{Tag: "relay"})
+	if got := h.acceptCount(); got != 1 {
+		t.Fatalf("accept count after transport = %d, want 1", got)
+	}
+}
+
+func TestIncomingAcceptFallbackWaitsForTransportAndSendsOnce(t *testing.T) {
+	h := newAcceptHarness(false, false)
+	if err := h.call.Answer(); err != nil {
+		t.Fatal(err)
+	}
+	if len(h.clock.timers) != 0 {
+		t.Fatal("fallback armed before relay transport was ready")
+	}
+	h.eng.mu.Lock()
+	h.eng.calls[h.call.id].relay = &relayData{}
+	h.eng.mu.Unlock()
+	h.eng.armIncomingAcceptFallback(h.call.id)
+	timer := h.clock.Timer(t, 0)
+	timer.Fire()
+	timer.Fire()
+	if err := h.eng.trySendFinalAccept(h.call.id, AcceptTriggerFallback); err != nil {
+		t.Fatal(err)
+	}
+	if got := h.acceptCount(); got != 1 {
+		t.Fatalf("accept count = %d, want 1", got)
+	}
+}
+
+func TestIncomingAcceptConcurrentMuteAndFallbackSendsOnce(t *testing.T) {
+	h := newAcceptHarness(true, true)
+	if err := h.call.Answer(); err != nil {
+		t.Fatal(err)
+	}
+	timer := h.clock.Timer(t, 0)
+	var wg sync.WaitGroup
+	wg.Add(2)
+	go func() { defer wg.Done(); timer.Fire() }()
+	go func() { defer wg.Done(); h.eng.onCallRaw(h.muteNode()) }()
+	wg.Wait()
+	if got := h.acceptCount(); got != 1 {
+		t.Fatalf("accept count = %d, want 1", got)
+	}
+}
+
+func TestIncomingAcceptAnswerIsIdempotent(t *testing.T) {
+	h := newAcceptHarness(false, true)
+	if err := h.call.Answer(); err != nil {
+		t.Fatal(err)
+	}
+	if err := h.call.Answer(); err != nil {
+		t.Fatal(err)
+	}
+	if len(h.clock.timers) != 1 {
+		t.Fatalf("timer count = %d, want 1", len(h.clock.timers))
+	}
+	h.clock.Timer(t, 0).Fire()
+	if got := h.acceptCount(); got != 1 {
+		t.Fatalf("accept count = %d, want 1", got)
+	}
+}
+
+func TestIncomingAcceptCleanupCancelsFallback(t *testing.T) {
+	tests := []struct {
+		name string
+		end  func(*acceptHarness)
+	}{
+		{"local_reject", func(h *acceptHarness) { _ = h.call.Reject() }},
+		{"remote_terminate", func(h *acceptHarness) { h.eng.onTerminate(h.call.id, "remote") }},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			h := newAcceptHarness(false, true)
+			if err := h.call.Answer(); err != nil {
+				t.Fatal(err)
+			}
+			timer := h.clock.Timer(t, 0)
+			tt.end(h)
+			timer.Fire()
+			h.eng.onCallRaw(h.muteNode())
+			if got := h.acceptCount(); got != 0 {
+				t.Fatalf("accept count after cleanup = %d, want 0", got)
+			}
+			if h.eng.lookup(h.call.id) != nil {
+				t.Fatal("call remained registered after cleanup")
+			}
+			if h.endCount != 1 {
+				t.Fatalf("end callbacks = %d, want 1", h.endCount)
+			}
+		})
+	}
+}
+
+func TestIncomingAcceptSendFailureIsTypedAndNotRetried(t *testing.T) {
+	h := newAcceptHarness(false, true)
+	h.sendErr = errors.New("write failed")
+	if err := h.call.Answer(); err != nil {
+		t.Fatal(err)
+	}
+	timer := h.clock.Timer(t, 0)
+	timer.Fire()
+	timer.Fire()
+	if got := h.acceptCount(); got != 1 {
+		t.Fatalf("send attempts = %d, want 1", got)
+	}
+	if h.eng.lookup(h.call.id) != nil || h.call.State() != CallPhaseEnded {
+		t.Fatal("failed accept did not clean up the call")
+	}
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	foundTypedFailure := false
+	for _, event := range h.events {
+		var typed *IncomingAcceptError
+		if errors.As(event.Err, &typed) && typed.Kind == "accept_send_failed" {
+			foundTypedFailure = true
+		}
+	}
+	if !foundTypedFailure {
+		t.Fatal("typed incoming accept failure event missing")
+	}
+}
+
+func TestIncomingAcceptEndDuringSendCancelsIOAndDoesNotCommit(t *testing.T) {
+	h := newAcceptHarness(false, true)
+	started := make(chan struct{})
+	h.sendFn = func(ctx context.Context, _ waBinary.Node) error {
+		close(started)
+		<-ctx.Done()
+		return ctx.Err()
+	}
+	if err := h.call.Answer(); err != nil {
+		t.Fatal(err)
+	}
+	timer := h.clock.Timer(t, 0)
+	done := make(chan struct{})
+	go func() {
+		timer.Fire()
+		close(done)
+	}()
+	<-started
+	h.eng.onTerminate(h.call.id, "remote")
+	<-done
+	if h.eng.lookup(h.call.id) != nil || h.call.State() != CallPhaseEnded {
+		t.Fatal("call was not cleaned up during accept send")
+	}
+	if got := h.acceptCount(); got != 1 {
+		t.Fatalf("send attempts = %d, want 1", got)
+	}
+}
+
+func TestIncomingAcceptVoiceAndVideoStanzas(t *testing.T) {
+	for _, video := range []bool{false, true} {
+		t.Run(map[bool]string{false: "voice", true: "video"}[video], func(t *testing.T) {
+			h := newAcceptHarness(video, true)
+			h.eng.onCallRaw(h.muteNode())
+			if err := h.call.Answer(); err != nil {
+				t.Fatal(err)
+			}
+			stanza := h.firstAccept(t)
+			accept := stanza.GetChildren()[0]
+			hasVideo := false
+			for _, child := range accept.GetChildren() {
+				if child.Tag == "video" {
+					hasVideo = true
+				}
+			}
+			if hasVideo != video {
+				t.Fatalf("video child = %v, want %v", hasVideo, video)
+			}
+		})
+	}
+}

--- a/incoming_accept_test.go
+++ b/incoming_accept_test.go
@@ -368,7 +368,7 @@ func TestIncomingAcceptEndDuringSendCancelsIOAndDoesNotCommit(t *testing.T) {
 	}
 }
 
-func TestIncomingAcceptVoiceAndVideoStanzas(t *testing.T) {
+func TestIncomingVoiceAndVideoUseTheSameFinalAcceptHandshake(t *testing.T) {
 	for _, video := range []bool{false, true} {
 		t.Run(map[bool]string{false: "voice", true: "video"}[video], func(t *testing.T) {
 			h := newAcceptHarness(video, true)
@@ -384,8 +384,8 @@ func TestIncomingAcceptVoiceAndVideoStanzas(t *testing.T) {
 					hasVideo = true
 				}
 			}
-			if hasVideo != video {
-				t.Fatalf("video child = %v, want %v", hasVideo, video)
+			if hasVideo {
+				t.Fatal("final accept included an experimental video child")
 			}
 		})
 	}

--- a/incoming_accept_test.go
+++ b/incoming_accept_test.go
@@ -3,6 +3,7 @@ package meowcaller
 import (
 	"context"
 	"errors"
+	"reflect"
 	"sync"
 	"testing"
 	"time"
@@ -146,9 +147,12 @@ func TestIncomingFinalAcceptCarriesSelectedRelayEndpointAndCapability(t *testing
 	if capability == nil {
 		t.Fatal("final accept omitted the negotiated capability")
 	}
+	if id := accept.AttrGetter().String("id"); id == "" {
+		t.Fatal("final accept omitted the wrapper id")
+	}
 }
 
-func TestIncomingVideoAdvertisesCalleeEncoderInFinalAcceptExactlyOnce(t *testing.T) {
+func TestIncomingVideoUsesCapturedCalleeShapeInFinalAcceptExactlyOnce(t *testing.T) {
 	h := newAcceptHarness(true, true)
 	h.eng.onCallRaw(h.muteNode())
 	if err := h.call.Answer(); err != nil {
@@ -175,14 +179,108 @@ func TestIncomingVideoAdvertisesCalleeEncoderInFinalAcceptExactlyOnce(t *testing
 	if video == nil {
 		t.Fatal("final accept omitted the callee video marker")
 	}
-	if got := video.AttrGetter().String("enc"); got != signaling.VideoCodecH264 {
-		t.Fatalf("final accept video enc = %q, want %s", got, signaling.VideoCodecH264)
+	if got := video.AttrGetter().String("dec"); got != signaling.VideoStateDecH264 {
+		t.Fatalf("final accept video dec = %q, want %s", got, signaling.VideoStateDecH264)
 	}
-	if got := video.AttrGetter().String("dec"); got != "" {
-		t.Fatalf("final accept video dec = %q, want absent", got)
+	if got := video.AttrGetter().String("device_orientation"); got != "0" {
+		t.Fatalf("final accept video device_orientation = %q, want 0", got)
 	}
-	if got := video.AttrGetter().String("device_orientation"); got != "" {
-		t.Fatalf("final accept video device_orientation = %q, want absent", got)
+	if got := video.AttrGetter().String("enc"); got != "" {
+		t.Fatalf("final accept video enc = %q, want absent", got)
+	}
+}
+
+func TestCaptureIncomingAcceptMetadata(t *testing.T) {
+	tests := []struct {
+		name  string
+		offer *waBinary.Node
+		want  waBinary.Attrs
+	}{
+		{
+			name: "both supported fields",
+			offer: &waBinary.Node{Tag: "offer", Content: []waBinary.Node{{
+				Tag: "metadata", Attrs: waBinary.Attrs{
+					"peer_abtest_bucket":         "bucket-a",
+					"peer_abtest_bucket_id_list": "11,22",
+					"unknown":                    "must-not-echo",
+				},
+			}}},
+			want: waBinary.Attrs{
+				"peer_abtest_bucket":         "bucket-a",
+				"peer_abtest_bucket_id_list": "11,22",
+			},
+		},
+		{
+			name: "one supported field",
+			offer: &waBinary.Node{Tag: "offer", Content: []waBinary.Node{{
+				Tag: "metadata", Attrs: waBinary.Attrs{"peer_abtest_bucket": ""},
+			}}},
+			want: waBinary.Attrs{"peer_abtest_bucket": ""},
+		},
+		{
+			name: "non-string and unknown fields",
+			offer: &waBinary.Node{Tag: "offer", Content: []waBinary.Node{{
+				Tag: "metadata", Attrs: waBinary.Attrs{"peer_abtest_bucket": 42, "unknown": "value"},
+			}}},
+		},
+		{name: "no metadata", offer: &waBinary.Node{Tag: "offer"}},
+		{name: "nil offer"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := captureIncomingAcceptMetadata(tt.offer); !reflect.DeepEqual(got, tt.want) {
+				t.Fatalf("metadata = %#v, want %#v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestIncomingFinalAcceptEchoesOnlyOfferMetadata(t *testing.T) {
+	h := newAcceptHarness(true, true)
+	offer := &waBinary.Node{Tag: "offer", Content: []waBinary.Node{{
+		Tag: "metadata", Attrs: waBinary.Attrs{
+			"peer_abtest_bucket":         "bucket-live",
+			"peer_abtest_bucket_id_list": "7,9",
+			"unknown":                    "must-not-echo",
+		},
+	}}}
+	h.eng.calls[h.call.id].acceptMetadata = captureIncomingAcceptMetadata(offer)
+	h.eng.onCallRaw(h.muteNode())
+	if err := h.call.Answer(); err != nil {
+		t.Fatal(err)
+	}
+	accept := h.firstAccept(t)
+	action := accept.GetChildren()[0]
+	var metadata *waBinary.Node
+	for i := range action.GetChildren() {
+		child := &action.GetChildren()[i]
+		if child.Tag == "metadata" {
+			metadata = child
+		}
+	}
+	if metadata == nil {
+		t.Fatal("final accept omitted offer metadata")
+	}
+	want := waBinary.Attrs{
+		"peer_abtest_bucket":         "bucket-live",
+		"peer_abtest_bucket_id_list": "7,9",
+	}
+	if !reflect.DeepEqual(metadata.Attrs, want) {
+		t.Fatalf("final accept metadata = %#v, want %#v", metadata.Attrs, want)
+	}
+}
+
+func TestIncomingFinalAcceptOmitsMetadataWhenOfferHasNone(t *testing.T) {
+	h := newAcceptHarness(true, true)
+	h.eng.onCallRaw(h.muteNode())
+	if err := h.call.Answer(); err != nil {
+		t.Fatal(err)
+	}
+	accept := h.firstAccept(t)
+	for _, child := range accept.GetChildren()[0].GetChildren() {
+		if child.Tag == "metadata" {
+			t.Fatal("final accept unexpectedly contains metadata")
+		}
 	}
 }
 

--- a/incoming_accept_test.go
+++ b/incoming_accept_test.go
@@ -119,7 +119,8 @@ func newAcceptHarness(video, relayReady bool) *acceptHarness {
 	return h
 }
 
-func TestIncomingFinalAcceptCarriesSelectedRelayEndpointAndCapability(t *testing.T) {
+func TestIncomingVideoFinalAcceptPreservesElectedRelayByOmittingTeAndCapability(t *testing.T) {
+	// Source of truth: https://github.com/oxidezap/whatsapp-rust/blob/d37b1756d05fb34c9b6c2410c48dd20d27394929/examples/voip-cli/src/main.rs#L1182-L1197
 	h := newAcceptHarness(true, true)
 	h.eng.onCallRaw(h.muteNode())
 	if err := h.call.Answer(); err != nil {
@@ -138,17 +139,42 @@ func TestIncomingFinalAcceptCarriesSelectedRelayEndpointAndCapability(t *testing
 			capability = child
 		}
 	}
-	if relayTE == nil {
-		t.Fatal("final accept omitted the selected relay endpoint")
+	if relayTE != nil {
+		t.Fatal("video final accept unexpectedly echoed the caller's relay endpoint")
 	}
-	if got := nodeBytes(relayTE); string(got) != string([]byte{57, 144, 233, 57, 0x0d, 0x96}) {
-		t.Fatalf("final accept relay endpoint = %x, want selected relay endpoint", got)
-	}
-	if capability == nil {
-		t.Fatal("final accept omitted the negotiated capability")
+	if capability != nil {
+		t.Fatal("video final accept unexpectedly advertised a capability")
 	}
 	if id := accept.AttrGetter().String("id"); id == "" {
 		t.Fatal("final accept omitted the wrapper id")
+	}
+}
+
+func TestIncomingVoiceFinalAcceptKeepsCapabilityWithoutEchoingRelayEndpoint(t *testing.T) {
+	// Source of truth: https://github.com/oxidezap/whatsapp-rust/blob/d37b1756d05fb34c9b6c2410c48dd20d27394929/examples/voip-cli/src/main.rs#L1182-L1197
+	h := newAcceptHarness(false, true)
+	h.eng.onCallRaw(h.muteNode())
+	if err := h.call.Answer(); err != nil {
+		t.Fatal(err)
+	}
+
+	accept := h.firstAccept(t)
+	action := accept.GetChildren()[0]
+	var capability *waBinary.Node
+	for i := range action.GetChildren() {
+		child := &action.GetChildren()[i]
+		if child.Tag == "te" {
+			t.Fatal("voice final accept unexpectedly echoed the caller's relay endpoint")
+		}
+		if child.Tag == "capability" {
+			capability = child
+		}
+	}
+	if capability == nil {
+		t.Fatal("voice final accept omitted the negotiated capability")
+	}
+	if got := nodeBytes(capability); !reflect.DeepEqual(got, signaling.CapabilityOffer) {
+		t.Fatalf("voice final accept capability = %x, want %x", got, signaling.CapabilityOffer)
 	}
 }
 

--- a/incoming_accept_test.go
+++ b/incoming_accept_test.go
@@ -148,7 +148,7 @@ func TestIncomingFinalAcceptCarriesSelectedRelayEndpointAndCapability(t *testing
 	}
 }
 
-func TestIncomingVideoAnnouncesLocalVideoAfterFinalAcceptExactlyOnce(t *testing.T) {
+func TestIncomingVideoNegotiatesCalleeVideoInFinalAcceptExactlyOnce(t *testing.T) {
 	h := newAcceptHarness(true, true)
 	h.eng.onCallRaw(h.muteNode())
 	if err := h.call.Answer(); err != nil {
@@ -159,18 +159,27 @@ func TestIncomingVideoAnnouncesLocalVideoAfterFinalAcceptExactlyOnce(t *testing.
 	h.mu.Lock()
 	nodes := append([]waBinary.Node(nil), h.nodes...)
 	h.mu.Unlock()
-	if len(nodes) != 2 {
-		t.Fatalf("sent nodes = %d, want final accept followed by one video announcement", len(nodes))
+	if len(nodes) != 1 {
+		t.Fatalf("sent nodes = %d, want exactly one final accept and no standalone video announcement", len(nodes))
 	}
 	if got := nodes[0].GetChildren()[0].Tag; got != "accept" {
 		t.Fatalf("first action = %s, want accept", got)
 	}
-	video := nodes[1].GetChildren()[0]
-	if video.Tag != "video" || video.AttrGetter().Int("state") != signaling.VideoStateEnabled {
-		t.Fatalf("second action = <%s state=%d>, want <video state=1>", video.Tag, video.AttrGetter().Int("state"))
+	var video *waBinary.Node
+	for i := range nodes[0].GetChildren()[0].GetChildren() {
+		child := &nodes[0].GetChildren()[0].GetChildren()[i]
+		if child.Tag == "video" {
+			video = child
+		}
+	}
+	if video == nil {
+		t.Fatal("final accept omitted the callee video marker")
 	}
 	if got := video.AttrGetter().String("dec"); got != signaling.VideoStateDecH264 {
-		t.Fatalf("video announcement dec = %q, want H264", got)
+		t.Fatalf("final accept video dec = %q, want H264", got)
+	}
+	if got := video.AttrGetter().String("device_orientation"); got != "0" {
+		t.Fatalf("final accept video device_orientation = %q, want 0", got)
 	}
 }
 
@@ -395,7 +404,7 @@ func TestIncomingAcceptEndDuringSendCancelsIOAndDoesNotCommit(t *testing.T) {
 	}
 }
 
-func TestIncomingVoiceAndVideoUseTheSameFinalAcceptHandshake(t *testing.T) {
+func TestIncomingVoiceAcceptStaysAudioOnlyAndVideoAcceptAdvertisesDecoder(t *testing.T) {
 	for _, video := range []bool{false, true} {
 		t.Run(map[bool]string{false: "voice", true: "video"}[video], func(t *testing.T) {
 			h := newAcceptHarness(video, true)
@@ -411,8 +420,8 @@ func TestIncomingVoiceAndVideoUseTheSameFinalAcceptHandshake(t *testing.T) {
 					hasVideo = true
 				}
 			}
-			if hasVideo {
-				t.Fatal("final accept included an experimental video child")
+			if hasVideo != video {
+				t.Fatalf("final accept has video child = %t, want %t", hasVideo, video)
 			}
 		})
 	}

--- a/livecall.go
+++ b/livecall.go
@@ -32,6 +32,7 @@ type Call struct {
 	onVideoState           func(VideoState)
 	onVideoKeyframeRequest func()
 	onReaction             func(CallReaction)
+	onIncomingAccept       func(IncomingAcceptEvent)
 }
 
 // CallReaction is a transient emoji reaction received over the call's RTC app-data stream.
@@ -180,6 +181,25 @@ func (c *Call) OnReaction(fn func(CallReaction)) {
 	c.mu.Lock()
 	c.onReaction = fn
 	c.mu.Unlock()
+}
+
+// OnIncomingAccept registers diagnostics for the final accept lifecycle of an
+// incoming call. The callback never contains raw stanzas or key material.
+func (c *Call) OnIncomingAccept(fn func(IncomingAcceptEvent)) {
+	// Source of truth: https://github.com/WhiskeySockets/wacrg/blob/0114515cef5c0344a8a864f6ad5ff58e650550ed/spec/signalling/flow-incoming-1to1.yaml#L82-L115
+	c.mu.Lock()
+	c.onIncomingAccept = fn
+	c.mu.Unlock()
+}
+
+func (c *Call) notifyIncomingAccept(event IncomingAcceptEvent) {
+	// Source of truth: https://github.com/WhiskeySockets/wacrg/blob/0114515cef5c0344a8a864f6ad5ff58e650550ed/spec/signalling/flow-incoming-1to1.yaml#L82-L115
+	c.mu.Lock()
+	fn := c.onIncomingAccept
+	c.mu.Unlock()
+	if fn != nil {
+		fn(event)
+	}
 }
 
 func (c *Call) onReactionFn() func(CallReaction) {

--- a/logging.go
+++ b/logging.go
@@ -3,6 +3,7 @@ package meowcaller
 import (
 	"github.com/purpshell/meowcaller/diag"
 	"github.com/rs/zerolog"
+	"time"
 )
 
 // Option configures optional, non-behavioral aspects of the call/media types —
@@ -10,16 +11,28 @@ import (
 type Option func(*config)
 
 type config struct {
-	log  zerolog.Logger
-	diag *diag.Recorder
+	log                           zerolog.Logger
+	diag                          *diag.Recorder
+	incomingAcceptFallbackTimeout time.Duration
 }
 
 func resolveConfig(opts []Option) config {
-	c := config{log: zerolog.Nop()}
+	c := config{log: zerolog.Nop(), incomingAcceptFallbackTimeout: 1500 * time.Millisecond}
 	for _, opt := range opts {
 		opt(&c)
 	}
 	return c
+}
+
+// WithIncomingAcceptFallbackTimeout sets how long an answered incoming call waits
+// for the peer's optional mute_v2 signal after relay transport is ready.
+func WithIncomingAcceptFallbackTimeout(timeout time.Duration) Option {
+	// Source of truth: https://github.com/WhiskeySockets/wacrg/blob/0114515cef5c0344a8a864f6ad5ff58e650550ed/spec/signalling/call-mute.yaml#L22-L34
+	return func(c *config) {
+		if timeout > 0 {
+			c.incomingAcceptFallbackTimeout = timeout
+		}
+	}
 }
 
 // WithLogger sets the zerolog logger for debug/trace diagnostics. The library never

--- a/signaling/stanza.go
+++ b/signaling/stanza.go
@@ -15,13 +15,13 @@ import (
 // from random bytes are passed in so the builders stay pure.
 
 // CapabilityOffer is the capability blob for <offer>/<accept> (ver=1).
-var CapabilityOffer = []byte{0x01, 0x05, 0xf7, 0x09, 0xe0, 0xbb, 0x13}
+var CapabilityOffer = []byte{0x01, 0x05, 0xf7, 0x09, 0xe4, 0xbb, 0x13}
 
 // CapabilityVideoOffer is the capability blob observed in WhatsApp video offers.
 var CapabilityVideoOffer = []byte{0x01, 0x05, 0xf7, 0x09, 0xe0, 0xfa, 0x13}
 
 // CapabilityPreaccept is the capability blob for <preaccept> (ver=1).
-var CapabilityPreaccept = []byte{0x01, 0x05, 0xf7, 0x09, 0xe0, 0xbb, 0x07}
+var CapabilityPreaccept = []byte{0x01, 0x05, 0xf7, 0x09, 0xe4, 0xbb, 0x07}
 
 // EncodeLatency is the relay latency wire encoding: 0x2000000 + rttMs.
 func EncodeLatency(rttMs uint32) string {
@@ -120,10 +120,10 @@ type AcceptParams struct {
 	VoipSettings []byte         // nil = absent
 	Capability   []byte         // nil = absent
 	Metadata     waBinary.Attrs // nil = absent
-	Video        bool           // true = advertise <video> (video call)
+	Video        bool           // retained for API compatibility; the offer carries the video marker
 }
 
-// BuildAccept builds <accept>: audio → [video] → [te priority=2] → net medium=2 → encopt →
+// BuildAccept builds <accept>: audio → [te priority=2] → net medium=2 → encopt →
 // [capability] → [metadata] → [rte] → [voip_settings].
 func BuildAccept(p *AcceptParams, log ...zerolog.Logger) waBinary.Node {
 	// Source of truth: https://github.com/oxidezap/whatsapp-rust/blob/41095d4e6ba4610e054e9ede3af1d5e88a83faee/wacore/src/voip/stanza.rs#L124-L162
@@ -140,9 +140,6 @@ func BuildAccept(p *AcceptParams, log ...zerolog.Logger) waBinary.Node {
 	children := make([]waBinary.Node, 0, len(p.AudioRates)+5)
 	for _, rate := range p.AudioRates {
 		children = append(children, audioOpus(rate))
-	}
-	if p.Video {
-		children = append(children, videoAcceptNode())
 	}
 	if p.RelayTe != nil {
 		children = append(children, waBinary.Node{Tag: "te", Attrs: waBinary.Attrs{"priority": "2"}, Content: p.RelayTe})
@@ -170,7 +167,7 @@ func audioOpus(rate string) waBinary.Node {
 	return waBinary.Node{Tag: "audio", Attrs: waBinary.Attrs{"enc": "opus", "rate": rate}}
 }
 
-// BuildPreaccept builds <preaccept>: audio → [video] → encopt → capability,
+// BuildPreaccept builds <preaccept>: audio → encopt → capability(preaccept blob),
 // wrapped with the random wrapper id.
 func BuildPreaccept(callID string, to, callCreator types.JID, wrapperID string, audioRates []string, video bool, log ...zerolog.Logger) waBinary.Node {
 	// Source of truth: https://github.com/oxidezap/whatsapp-rust/blob/41095d4e6ba4610e054e9ede3af1d5e88a83faee/wacore/src/voip/stanza.rs#L171-L201
@@ -179,20 +176,14 @@ func BuildPreaccept(callID string, to, callCreator types.JID, wrapperID string, 
 		Str("call_id", callID).
 		Str("wrapper_id", wrapperID).
 		Strs("audio_rates", audioRates).
+		Bool("video_offer", video).
 		Msg("building preaccept stanza")
-	children := make([]waBinary.Node, 0, len(audioRates)+3)
+	children := make([]waBinary.Node, 0, len(audioRates)+2)
 	for _, rate := range audioRates {
 		children = append(children, audioOpus(rate))
 	}
-	if video {
-		children = append(children, videoPreacceptNode())
-	}
 	children = append(children, waBinary.Node{Tag: "encopt", Attrs: waBinary.Attrs{"keygen": "2"}})
-	capability := CapabilityPreaccept
-	if video {
-		capability = CapabilityOffer
-	}
-	children = append(children, waBinary.Node{Tag: "capability", Attrs: waBinary.Attrs{"ver": "1"}, Content: capability})
+	children = append(children, waBinary.Node{Tag: "capability", Attrs: waBinary.Attrs{"ver": "1"}, Content: CapabilityPreaccept})
 	return callWrap(to, &wrapperID, offerAction("preaccept", callID, callCreator, children))
 }
 

--- a/signaling/stanza.go
+++ b/signaling/stanza.go
@@ -120,13 +120,13 @@ type AcceptParams struct {
 	VoipSettings []byte         // nil = absent
 	Capability   []byte         // nil = absent
 	Metadata     waBinary.Attrs // nil = absent
-	Video        bool           // retained for API compatibility; the offer carries the video marker
+	Video        bool           // true = include the captured callee-side <video> marker
 }
 
-// BuildAccept builds <accept>: audio → [te priority=2] → net medium=2 → encopt →
+// BuildAccept builds <accept>: audio → [video] → [te priority=2] → net medium=2 → encopt →
 // [capability] → [metadata] → [rte] → [voip_settings].
 func BuildAccept(p *AcceptParams, log ...zerolog.Logger) waBinary.Node {
-	// Source of truth: https://github.com/oxidezap/whatsapp-rust/blob/41095d4e6ba4610e054e9ede3af1d5e88a83faee/wacore/src/voip/stanza.rs#L124-L162
+	// Source of truth: https://github.com/oxidezap/whatsapp-rust/blob/d37b1756d05fb34c9b6c2410c48dd20d27394929/wacore/src/stanza/call.rs#L542-L608
 	lg := pickLog(log)
 	lg.Debug().
 		Str("call_id", p.CallID).
@@ -136,10 +136,14 @@ func BuildAccept(p *AcceptParams, log ...zerolog.Logger) waBinary.Node {
 		Bool("has_voip_settings", p.VoipSettings != nil).
 		Bool("has_capability", p.Capability != nil).
 		Bool("has_metadata", p.Metadata != nil).
+		Bool("video", p.Video).
 		Msg("building accept stanza")
-	children := make([]waBinary.Node, 0, len(p.AudioRates)+5)
+	children := make([]waBinary.Node, 0, len(p.AudioRates)+6)
 	for _, rate := range p.AudioRates {
 		children = append(children, audioOpus(rate))
+	}
+	if p.Video {
+		children = append(children, videoAcceptNode())
 	}
 	if p.RelayTe != nil {
 		children = append(children, waBinary.Node{Tag: "te", Attrs: waBinary.Attrs{"priority": "2"}, Content: p.RelayTe})

--- a/signaling/stanza.go
+++ b/signaling/stanza.go
@@ -14,14 +14,15 @@ import (
 // is load-bearing (the server returns 439 if it is wrong). Stanza ids generated
 // from random bytes are passed in so the builders stay pure.
 
-// CapabilityOffer is the capability blob for <offer>/<accept> (ver=1).
-var CapabilityOffer = []byte{0x01, 0x05, 0xf7, 0x09, 0xe4, 0xbb, 0x13}
+// CapabilityOffer is the capability blob for <offer>/<accept>/video <preaccept> (ver=1).
+// Source of truth: https://github.com/oxidezap/whatsapp-rust/blob/d37b1756d05fb34c9b6c2410c48dd20d27394929/wacore/src/stanza/call.rs#L397-L405
+var CapabilityOffer = []byte{0x01, 0x05, 0xf7, 0x09, 0xe0, 0xbb, 0x13}
 
 // CapabilityVideoOffer is the capability blob observed in WhatsApp video offers.
 var CapabilityVideoOffer = []byte{0x01, 0x05, 0xf7, 0x09, 0xe0, 0xfa, 0x13}
 
-// CapabilityPreaccept is the capability blob for <preaccept> (ver=1).
-var CapabilityPreaccept = []byte{0x01, 0x05, 0xf7, 0x09, 0xe4, 0xbb, 0x07}
+// CapabilityPreaccept is the capability blob for an audio-only <preaccept> (ver=1).
+var CapabilityPreaccept = []byte{0x01, 0x05, 0xf7, 0x09, 0xe0, 0xbb, 0x07}
 
 // EncodeLatency is the relay latency wire encoding: 0x2000000 + rttMs.
 func EncodeLatency(rttMs uint32) string {
@@ -113,6 +114,7 @@ func encNode(dk OfferDeviceKey) waBinary.Node {
 type AcceptParams struct {
 	CallID       string
 	To           types.JID
+	WrapperID    string // required id on the outer <call> stanza
 	CallCreator  types.JID
 	AudioRates   []string
 	RelayTe      []byte         // nil = absent
@@ -123,8 +125,8 @@ type AcceptParams struct {
 	Video        bool           // true = include the captured callee-side <video> marker
 }
 
-// BuildAccept builds <accept>: audio → [te priority=2] → net medium=2 → encopt →
-// [capability] → [metadata] → [rte] → [voip_settings] → [video].
+// BuildAccept builds <accept>: audio → [video] → [te priority=2] → net medium=2 →
+// encopt → [metadata] → [capability] → [rte] → [voip_settings].
 func BuildAccept(p *AcceptParams, log ...zerolog.Logger) waBinary.Node {
 	// Source of truth: https://github.com/JotaDev66/WaCalls/blob/2d6a1f666426049a89ef9541414e771acdcf8a16/internal/voip/signaling/signaling_build.go#L85-L126
 	lg := pickLog(log)
@@ -142,16 +144,22 @@ func BuildAccept(p *AcceptParams, log ...zerolog.Logger) waBinary.Node {
 	for _, rate := range p.AudioRates {
 		children = append(children, audioOpus(rate))
 	}
+	if p.Video {
+		// Source of truth: https://github.com/oxidezap/whatsapp-rust/blob/d37b1756d05fb34c9b6c2410c48dd20d27394929/wacore/src/stanza/call.rs#L542-L546
+		children = append(children, videoAcceptNode())
+	}
 	if p.RelayTe != nil {
 		children = append(children, waBinary.Node{Tag: "te", Attrs: waBinary.Attrs{"priority": "2"}, Content: p.RelayTe})
 	}
 	children = append(children, waBinary.Node{Tag: "net", Attrs: waBinary.Attrs{"medium": "2"}})
 	children = append(children, waBinary.Node{Tag: "encopt", Attrs: waBinary.Attrs{"keygen": "2"}})
-	if p.Capability != nil {
-		children = append(children, waBinary.Node{Tag: "capability", Attrs: waBinary.Attrs{"ver": "1"}, Content: p.Capability})
-	}
 	if p.Metadata != nil {
+		// Source of truth: https://github.com/oxidezap/whatsapp-rust/blob/d37b1756d05fb34c9b6c2410c48dd20d27394929/wacore/src/stanza/call.rs#L557-L566
 		children = append(children, waBinary.Node{Tag: "metadata", Attrs: p.Metadata})
+	}
+	if p.Capability != nil {
+		// Source of truth: https://github.com/oxidezap/whatsapp-rust/blob/d37b1756d05fb34c9b6c2410c48dd20d27394929/wacore/src/stanza/call.rs#L557-L569
+		children = append(children, waBinary.Node{Tag: "capability", Attrs: waBinary.Attrs{"ver": "1"}, Content: p.Capability})
 	}
 	if p.Rte != nil {
 		children = append(children, waBinary.Node{Tag: "rte", Content: p.Rte})
@@ -159,10 +167,7 @@ func BuildAccept(p *AcceptParams, log ...zerolog.Logger) waBinary.Node {
 	if p.VoipSettings != nil {
 		children = append(children, waBinary.Node{Tag: "voip_settings", Attrs: waBinary.Attrs{"uncompressed": "1"}, Content: p.VoipSettings})
 	}
-	if p.Video {
-		children = append(children, videoAcceptNode())
-	}
-	return callWrap(p.To, nil, offerAction("accept", p.CallID, p.CallCreator, children))
+	return callWrap(p.To, &p.WrapperID, offerAction("accept", p.CallID, p.CallCreator, children))
 }
 
 // audioOpus builds one <audio enc=opus rate=…> advertisement child.
@@ -171,8 +176,8 @@ func audioOpus(rate string) waBinary.Node {
 	return waBinary.Node{Tag: "audio", Attrs: waBinary.Attrs{"enc": "opus", "rate": rate}}
 }
 
-// BuildPreaccept builds <preaccept>: audio → encopt → capability(preaccept blob),
-// wrapped with the random wrapper id.
+// BuildPreaccept builds <preaccept>: audio → [video] → encopt → capability,
+// wrapped with the random wrapper id. Video uses the offer/accept capability blob.
 func BuildPreaccept(callID string, to, callCreator types.JID, wrapperID string, audioRates []string, video bool, log ...zerolog.Logger) waBinary.Node {
 	// Source of truth: https://github.com/oxidezap/whatsapp-rust/blob/41095d4e6ba4610e054e9ede3af1d5e88a83faee/wacore/src/voip/stanza.rs#L171-L201
 	lg := pickLog(log)
@@ -182,12 +187,21 @@ func BuildPreaccept(callID string, to, callCreator types.JID, wrapperID string, 
 		Strs("audio_rates", audioRates).
 		Bool("video_offer", video).
 		Msg("building preaccept stanza")
-	children := make([]waBinary.Node, 0, len(audioRates)+2)
+	children := make([]waBinary.Node, 0, len(audioRates)+3)
 	for _, rate := range audioRates {
 		children = append(children, audioOpus(rate))
 	}
+	if video {
+		// Source of truth: https://github.com/oxidezap/whatsapp-rust/blob/d37b1756d05fb34c9b6c2410c48dd20d27394929/wacore/src/stanza/call.rs#L655-L664
+		children = append(children, videoPreacceptNode())
+	}
 	children = append(children, waBinary.Node{Tag: "encopt", Attrs: waBinary.Attrs{"keygen": "2"}})
-	children = append(children, waBinary.Node{Tag: "capability", Attrs: waBinary.Attrs{"ver": "1"}, Content: CapabilityPreaccept})
+	// Source of truth: https://github.com/oxidezap/whatsapp-rust/blob/d37b1756d05fb34c9b6c2410c48dd20d27394929/wacore/src/stanza/call.rs#L655-L664
+	capability := CapabilityPreaccept
+	if video {
+		capability = CapabilityOffer
+	}
+	children = append(children, waBinary.Node{Tag: "capability", Attrs: waBinary.Attrs{"ver": "1"}, Content: capability})
 	return callWrap(to, &wrapperID, offerAction("preaccept", callID, callCreator, children))
 }
 

--- a/signaling/stanza.go
+++ b/signaling/stanza.go
@@ -123,10 +123,10 @@ type AcceptParams struct {
 	Video        bool           // true = include the captured callee-side <video> marker
 }
 
-// BuildAccept builds <accept>: audio → [video] → [te priority=2] → net medium=2 → encopt →
-// [capability] → [metadata] → [rte] → [voip_settings].
+// BuildAccept builds <accept>: audio → [te priority=2] → net medium=2 → encopt →
+// [capability] → [metadata] → [rte] → [voip_settings] → [video].
 func BuildAccept(p *AcceptParams, log ...zerolog.Logger) waBinary.Node {
-	// Source of truth: https://github.com/oxidezap/whatsapp-rust/blob/d37b1756d05fb34c9b6c2410c48dd20d27394929/wacore/src/stanza/call.rs#L542-L608
+	// Source of truth: https://github.com/JotaDev66/WaCalls/blob/2d6a1f666426049a89ef9541414e771acdcf8a16/internal/voip/signaling/signaling_build.go#L85-L126
 	lg := pickLog(log)
 	lg.Debug().
 		Str("call_id", p.CallID).
@@ -141,9 +141,6 @@ func BuildAccept(p *AcceptParams, log ...zerolog.Logger) waBinary.Node {
 	children := make([]waBinary.Node, 0, len(p.AudioRates)+6)
 	for _, rate := range p.AudioRates {
 		children = append(children, audioOpus(rate))
-	}
-	if p.Video {
-		children = append(children, videoAcceptNode())
 	}
 	if p.RelayTe != nil {
 		children = append(children, waBinary.Node{Tag: "te", Attrs: waBinary.Attrs{"priority": "2"}, Content: p.RelayTe})
@@ -161,6 +158,9 @@ func BuildAccept(p *AcceptParams, log ...zerolog.Logger) waBinary.Node {
 	}
 	if p.VoipSettings != nil {
 		children = append(children, waBinary.Node{Tag: "voip_settings", Attrs: waBinary.Attrs{"uncompressed": "1"}, Content: p.VoipSettings})
+	}
+	if p.Video {
+		children = append(children, videoAcceptNode())
 	}
 	return callWrap(p.To, nil, offerAction("accept", p.CallID, p.CallCreator, children))
 }

--- a/signaling/stanza_test.go
+++ b/signaling/stanza_test.go
@@ -113,11 +113,14 @@ func TestOfferMultiDeviceUsesDestination(t *testing.T) {
 func TestAcceptAndPreacceptShape(t *testing.T) {
 	peer, creator := peerJID(), creatorJID()
 	accept := BuildAccept(&AcceptParams{
-		CallID: "CID", To: peer, CallCreator: creator,
+		CallID: "CID", To: peer, WrapperID: "accept-wrap", CallCreator: creator,
 		AudioRates: []string{"16000"}, RelayTe: make([]byte, 6), Capability: CapabilityOffer,
 	})
 	if got := childTags(t, accept); !eqTags(got, []string{"audio", "te", "net", "encopt", "capability"}) {
 		t.Errorf("accept tags = %v", got)
+	}
+	if id, _ := attrString(accept, "id"); id != "accept-wrap" {
+		t.Errorf("accept id = %q, want accept-wrap", id)
 	}
 	pre := BuildPreaccept("CID", peer, creator, "abcd1234", []string{"8000", "16000"}, false)
 	if got := childTags(t, pre); !eqTags(got, []string{"audio", "audio", "encopt", "capability"}) {

--- a/signaling/video.go
+++ b/signaling/video.go
@@ -9,9 +9,9 @@ import (
 )
 
 // Video call signaling follows the 1:1 video lifecycle implemented by whatsapp-rust.
-// A from-start video call advertises a <video> child in the offer. The answer keeps the
-// established audio-shaped preaccept/accept handshake; later state changes use standalone
-// <video state=N> call stanzas.
+// A from-start video call advertises a <video> child in the offer and final accept. The
+// preaccept remains audio-shaped; standalone <video state=N> stanzas are only for in-call
+// transitions such as upgrade, downgrade, and orientation changes.
 
 // VideoCodecH264 is the lowercase codec token used by bridge internals.
 const VideoCodecH264 = "h264"
@@ -117,6 +117,16 @@ func videoOfferNode() waBinary.Node {
 		"dec":                videoOfferDecH264,
 		"screen_width":       "1920",
 		"screen_height":      "1080",
+		"device_orientation": "0",
+	}}
+}
+
+// videoAcceptNode builds the captured callee marker for a from-start video final accept.
+// Its position immediately after the audio children is part of the observed wire shape.
+func videoAcceptNode() waBinary.Node {
+	// Source of truth: https://github.com/oxidezap/whatsapp-rust/blob/d37b1756d05fb34c9b6c2410c48dd20d27394929/wacore/src/stanza/call.rs#L603-L608
+	return waBinary.Node{Tag: "video", Attrs: waBinary.Attrs{
+		"dec":                VideoStateDecH264,
 		"device_orientation": "0",
 	}}
 }

--- a/signaling/video.go
+++ b/signaling/video.go
@@ -9,8 +9,9 @@ import (
 )
 
 // Video call signaling follows the 1:1 video lifecycle implemented by whatsapp-rust.
-// A from-start video call advertises a <video> child in the offer and accept. Mid-call
-// upgrades and downgrades use standalone <video state=N> call stanzas.
+// A from-start video call advertises a <video> child in the offer. The answer keeps the
+// established audio-shaped preaccept/accept handshake; later state changes use standalone
+// <video state=N> call stanzas.
 
 // VideoCodecH264 is the lowercase codec token used by bridge internals.
 const VideoCodecH264 = "h264"
@@ -117,24 +118,6 @@ func videoOfferNode() waBinary.Node {
 		"screen_width":       "1920",
 		"screen_height":      "1080",
 		"device_orientation": "0",
-	}}
-}
-
-// videoAcceptNode builds the <video> advertisement for an <accept>.
-func videoAcceptNode() waBinary.Node {
-	return waBinary.Node{Tag: "video", Attrs: waBinary.Attrs{
-		"dec":                VideoStateDecH264,
-		"device_orientation": "0",
-	}}
-}
-
-// videoPreacceptNode advertises the callee's decoder before the final accept.
-func videoPreacceptNode() waBinary.Node {
-	return waBinary.Node{Tag: "video", Attrs: waBinary.Attrs{
-		"dec":                VideoStateDecH264,
-		"device_orientation": "0",
-		"screen_width":       "0",
-		"screen_height":      "0",
 	}}
 }
 

--- a/signaling/video.go
+++ b/signaling/video.go
@@ -121,13 +121,12 @@ func videoOfferNode() waBinary.Node {
 	}}
 }
 
-// videoAcceptNode builds the captured callee marker for a from-start video final accept.
-// Its position immediately after the audio children is part of the observed wire shape.
+// videoAcceptNode advertises the callee's H.264 encoder at the end of a from-start
+// video final accept, preserving the established audio/relay child sequence.
 func videoAcceptNode() waBinary.Node {
-	// Source of truth: https://github.com/oxidezap/whatsapp-rust/blob/d37b1756d05fb34c9b6c2410c48dd20d27394929/wacore/src/stanza/call.rs#L603-L608
+	// Source of truth: https://github.com/JotaDev66/WaCalls/blob/2d6a1f666426049a89ef9541414e771acdcf8a16/internal/voip/signaling/signaling_build.go#L111-L113
 	return waBinary.Node{Tag: "video", Attrs: waBinary.Attrs{
-		"dec":                VideoStateDecH264,
-		"device_orientation": "0",
+		"enc": VideoCodecH264,
 	}}
 }
 

--- a/signaling/video.go
+++ b/signaling/video.go
@@ -9,9 +9,9 @@ import (
 )
 
 // Video call signaling follows the 1:1 video lifecycle implemented by whatsapp-rust.
-// A from-start video call advertises a <video> child in the offer and final accept. The
-// preaccept remains audio-shaped; standalone <video state=N> stanzas are only for in-call
-// transitions such as upgrade, downgrade, and orientation changes.
+// A from-start video call advertises a <video> child in the offer, preaccept, and final
+// accept. Standalone <video state=N> stanzas are only for in-call transitions such as
+// upgrade, downgrade, and orientation changes.
 
 // VideoCodecH264 is the lowercase codec token used by bridge internals.
 const VideoCodecH264 = "h264"
@@ -121,12 +121,24 @@ func videoOfferNode() waBinary.Node {
 	}}
 }
 
-// videoAcceptNode advertises the callee's H.264 encoder at the end of a from-start
-// video final accept, preserving the established audio/relay child sequence.
+// videoAcceptNode advertises the callee's H.264 decoder in a from-start video accept.
 func videoAcceptNode() waBinary.Node {
 	// Source of truth: https://github.com/JotaDev66/WaCalls/blob/2d6a1f666426049a89ef9541414e771acdcf8a16/internal/voip/signaling/signaling_build.go#L111-L113
+	// Source of truth: https://github.com/oxidezap/whatsapp-rust/blob/d37b1756d05fb34c9b6c2410c48dd20d27394929/wacore/src/stanza/call.rs#L604-L610
 	return waBinary.Node{Tag: "video", Attrs: waBinary.Attrs{
-		"enc": VideoCodecH264,
+		"dec":                VideoStateDecH264,
+		"device_orientation": "0",
+	}}
+}
+
+// videoPreacceptNode advertises the callee's decoder before the final accept.
+func videoPreacceptNode() waBinary.Node {
+	// Source of truth: https://github.com/oxidezap/whatsapp-rust/blob/d37b1756d05fb34c9b6c2410c48dd20d27394929/wacore/src/stanza/call.rs#L612-L621
+	return waBinary.Node{Tag: "video", Attrs: waBinary.Attrs{
+		"dec":                VideoStateDecH264,
+		"device_orientation": "0",
+		"screen_width":       "0",
+		"screen_height":      "0",
 	}}
 }
 

--- a/signaling/video_test.go
+++ b/signaling/video_test.go
@@ -48,16 +48,16 @@ func TestOfferAdvertisesVideo(t *testing.T) {
 	}
 }
 
-// TestFromStartVideoAcceptAdvertisesTheCalleeDecoder pins the captured answer shape:
-// unlike preaccept, the final accept carries the callee-side video decoder marker.
-func TestFromStartVideoAcceptAdvertisesTheCalleeDecoder(t *testing.T) {
+// TestFromStartVideoAcceptAdvertisesTheCalleeEncoder pins the WaCalls H.264 answer
+// shape: the video marker is appended after the established audio/relay handshake.
+func TestFromStartVideoAcceptAdvertisesTheCalleeEncoder(t *testing.T) {
 	peer, creator := peerJID(), creatorJID()
 	accept := BuildAccept(&AcceptParams{
 		CallID: "CID", To: peer, CallCreator: creator,
 		AudioRates: []string{"16000"}, RelayTe: make([]byte, 6),
 		Capability: CapabilityOffer, Video: true,
 	})
-	want := []string{"audio", "video", "te", "net", "encopt", "capability"}
+	want := []string{"audio", "te", "net", "encopt", "capability", "video"}
 	if got := childTags(t, accept); !eqTags(got, want) {
 		t.Errorf("accept tags = %v, want %v", got, want)
 	}
@@ -65,11 +65,14 @@ func TestFromStartVideoAcceptAdvertisesTheCalleeDecoder(t *testing.T) {
 	if !ok {
 		t.Fatal("from-start video accept omitted the callee video marker")
 	}
-	if dec, _ := attrString(video, "dec"); dec != "H264" {
-		t.Errorf("video accept dec = %q, want H264", dec)
+	if enc, _ := attrString(video, "enc"); enc != VideoCodecH264 {
+		t.Errorf("video accept enc = %q, want %s", enc, VideoCodecH264)
 	}
-	if orientation, _ := attrString(video, "device_orientation"); orientation != "0" {
-		t.Errorf("video accept device_orientation = %q, want 0", orientation)
+	if _, has := video.Attrs["dec"]; has {
+		t.Error("video accept must not carry the decoder-state attribute")
+	}
+	if _, has := video.Attrs["device_orientation"]; has {
+		t.Error("video accept must not carry a standalone-state orientation")
 	}
 }
 

--- a/signaling/video_test.go
+++ b/signaling/video_test.go
@@ -48,45 +48,82 @@ func TestOfferAdvertisesVideo(t *testing.T) {
 	}
 }
 
-// TestFromStartVideoAcceptAdvertisesTheCalleeEncoder pins the WaCalls H.264 answer
-// shape: the video marker is appended after the established audio/relay handshake.
-func TestFromStartVideoAcceptAdvertisesTheCalleeEncoder(t *testing.T) {
+// TestFromStartVideoAcceptMatchesCapturedCalleeShape pins the complete captured answer.
+func TestFromStartVideoAcceptMatchesCapturedCalleeShape(t *testing.T) {
 	peer, creator := peerJID(), creatorJID()
 	accept := BuildAccept(&AcceptParams{
-		CallID: "CID", To: peer, CallCreator: creator,
+		CallID: "CID", To: peer, WrapperID: "accept-wrap", CallCreator: creator,
 		AudioRates: []string{"16000"}, RelayTe: make([]byte, 6),
-		Capability: CapabilityOffer, Video: true,
+		Capability: CapabilityOffer,
+		Metadata: waBinary.Attrs{
+			"peer_abtest_bucket":         "bucket-a",
+			"peer_abtest_bucket_id_list": "11,22",
+		},
+		Video: true,
 	})
-	want := []string{"audio", "te", "net", "encopt", "capability", "video"}
+	want := []string{"audio", "video", "te", "net", "encopt", "metadata", "capability"}
 	if got := childTags(t, accept); !eqTags(got, want) {
 		t.Errorf("accept tags = %v, want %v", got, want)
+	}
+	if id, _ := attrString(accept, "id"); id != "accept-wrap" {
+		t.Errorf("accept wrapper id = %q, want accept-wrap", id)
 	}
 	video, ok := getChild(t, contentNodes(t, accept)[0], "video")
 	if !ok {
 		t.Fatal("from-start video accept omitted the callee video marker")
 	}
-	if enc, _ := attrString(video, "enc"); enc != VideoCodecH264 {
-		t.Errorf("video accept enc = %q, want %s", enc, VideoCodecH264)
+	if dec, _ := attrString(video, "dec"); dec != VideoStateDecH264 {
+		t.Errorf("video accept dec = %q, want %s", dec, VideoStateDecH264)
 	}
-	if _, has := video.Attrs["dec"]; has {
-		t.Error("video accept must not carry the decoder-state attribute")
+	if orientation, _ := attrString(video, "device_orientation"); orientation != "0" {
+		t.Errorf("video accept device_orientation = %q, want 0", orientation)
 	}
-	if _, has := video.Attrs["device_orientation"]; has {
-		t.Error("video accept must not carry a standalone-state orientation")
+	if _, has := video.Attrs["enc"]; has {
+		t.Error("video accept must not carry an encoder attribute")
+	}
+	action := contentNodes(t, accept)[0]
+	metadata, ok := getChild(t, action, "metadata")
+	if !ok {
+		t.Fatal("video accept metadata missing")
+	}
+	if got, _ := attrString(metadata, "peer_abtest_bucket"); got != "bucket-a" {
+		t.Errorf("peer_abtest_bucket = %q, want bucket-a", got)
+	}
+	if got, _ := attrString(metadata, "peer_abtest_bucket_id_list"); got != "11,22" {
+		t.Errorf("peer_abtest_bucket_id_list = %q, want 11,22", got)
+	}
+	capability, ok := getChild(t, action, "capability")
+	if !ok {
+		t.Fatal("video accept capability missing")
+	}
+	wantCapability := []byte{0x01, 0x05, 0xf7, 0x09, 0xe0, 0xbb, 0x13}
+	if got, ok := capability.Content.([]byte); !ok || !bytes.Equal(got, wantCapability) {
+		t.Errorf("video accept capability = %x, want %x", got, wantCapability)
 	}
 }
 
-func TestVideoPreacceptUsesPreacceptCapability(t *testing.T) {
+func TestVideoPreacceptMatchesCapturedCalleeShape(t *testing.T) {
 	peer, creator := peerJID(), creatorJID()
 	pre := BuildPreaccept("CID", peer, creator, "wrap", []string{"16000"}, true)
 
-	want := []string{"audio", "encopt", "capability"}
+	want := []string{"audio", "video", "encopt", "capability"}
 	if got := childTags(t, pre); !eqTags(got, want) {
 		t.Errorf("video preaccept tags = %v, want %v", got, want)
 	}
 	action := contentNodes(t, pre)[0]
-	if _, ok := getChild(t, action, "video"); ok {
-		t.Fatal("video preaccept must not carry an experimental video child")
+	video, ok := getChild(t, action, "video")
+	if !ok {
+		t.Fatal("video preaccept child missing")
+	}
+	for attr, wantValue := range map[string]string{
+		"dec":                "H264",
+		"device_orientation": "0",
+		"screen_width":       "0",
+		"screen_height":      "0",
+	} {
+		if got, _ := attrString(video, attr); got != wantValue {
+			t.Errorf("video preaccept %s = %q, want %q", attr, got, wantValue)
+		}
 	}
 	capability, ok := getChild(t, action, "capability")
 	if !ok {
@@ -96,9 +133,62 @@ func TestVideoPreacceptUsesPreacceptCapability(t *testing.T) {
 	if !ok {
 		t.Fatalf("video preaccept capability content = %T, want []byte", capability.Content)
 	}
-	wantCapability := []byte{0x01, 0x05, 0xf7, 0x09, 0xe4, 0xbb, 0x07}
+	wantCapability := []byte{0x01, 0x05, 0xf7, 0x09, 0xe0, 0xbb, 0x13}
 	if !bytes.Equal(gotCapability, wantCapability) {
 		t.Errorf("video preaccept capability = %x, want %x", gotCapability, wantCapability)
+	}
+}
+
+func TestVoicePreacceptKeepsAudioOnlyCapability(t *testing.T) {
+	peer, creator := peerJID(), creatorJID()
+	pre := BuildPreaccept("CID", peer, creator, "wrap", []string{"16000"}, false)
+	action := contentNodes(t, pre)[0]
+	if _, ok := getChild(t, action, "video"); ok {
+		t.Fatal("voice preaccept unexpectedly contains video")
+	}
+	capability, ok := getChild(t, action, "capability")
+	if !ok {
+		t.Fatal("voice preaccept capability missing")
+	}
+	want := []byte{0x01, 0x05, 0xf7, 0x09, 0xe0, 0xbb, 0x07}
+	if got, ok := capability.Content.([]byte); !ok || !bytes.Equal(got, want) {
+		t.Errorf("voice preaccept capability = %x, want %x", got, want)
+	}
+}
+
+func TestVoiceOfferAndAcceptUseCapturedCapabilityWithoutVideo(t *testing.T) {
+	peer, creator := peerJID(), creatorJID()
+	dk := OfferDeviceKey{DeviceJid: peer, Ciphertext: []byte{1}, EncType: "pkmsg"}
+	offer := BuildOffer(&OfferParams{
+		CallID: "CID", To: peer, CallCreator: creator,
+		DeviceKeys: []OfferDeviceKey{dk}, Capability: CapabilityOffer,
+	})
+	offerAction := contentNodes(t, offer)[0]
+	if _, ok := getChild(t, offerAction, "video"); ok {
+		t.Fatal("voice offer unexpectedly contains video")
+	}
+	assertCapabilityBytes(t, offerAction, []byte{0x01, 0x05, 0xf7, 0x09, 0xe0, 0xbb, 0x13})
+
+	accept := BuildAccept(&AcceptParams{
+		CallID: "CID", To: peer, WrapperID: "accept-wrap", CallCreator: creator,
+		AudioRates: []string{"16000"}, Capability: CapabilityOffer,
+	})
+	acceptAction := contentNodes(t, accept)[0]
+	if _, ok := getChild(t, acceptAction, "video"); ok {
+		t.Fatal("voice accept unexpectedly contains video")
+	}
+	assertCapabilityBytes(t, acceptAction, []byte{0x01, 0x05, 0xf7, 0x09, 0xe0, 0xbb, 0x13})
+}
+
+func assertCapabilityBytes(t *testing.T, action waBinary.Node, want []byte) {
+	t.Helper()
+	capability, ok := getChild(t, action, "capability")
+	if !ok {
+		t.Fatal("capability child missing")
+	}
+	got, ok := capability.Content.([]byte)
+	if !ok || !bytes.Equal(got, want) {
+		t.Errorf("capability = %x, want %x", got, want)
 	}
 }
 

--- a/signaling/video_test.go
+++ b/signaling/video_test.go
@@ -48,22 +48,28 @@ func TestOfferAdvertisesVideo(t *testing.T) {
 	}
 }
 
-// TestFromStartVideoAcceptUsesTheEstablishedHandshake pins the observed answer shape:
-// the offer marks the call as video, while preaccept/accept keep the same media-selection
-// children as audio. Video state is announced separately after acceptance.
-func TestFromStartVideoAcceptUsesTheEstablishedHandshake(t *testing.T) {
+// TestFromStartVideoAcceptAdvertisesTheCalleeDecoder pins the captured answer shape:
+// unlike preaccept, the final accept carries the callee-side video decoder marker.
+func TestFromStartVideoAcceptAdvertisesTheCalleeDecoder(t *testing.T) {
 	peer, creator := peerJID(), creatorJID()
 	accept := BuildAccept(&AcceptParams{
 		CallID: "CID", To: peer, CallCreator: creator,
 		AudioRates: []string{"16000"}, RelayTe: make([]byte, 6),
 		Capability: CapabilityOffer, Video: true,
 	})
-	want := []string{"audio", "te", "net", "encopt", "capability"}
+	want := []string{"audio", "video", "te", "net", "encopt", "capability"}
 	if got := childTags(t, accept); !eqTags(got, want) {
 		t.Errorf("accept tags = %v, want %v", got, want)
 	}
-	if _, ok := getChild(t, contentNodes(t, accept)[0], "video"); ok {
-		t.Fatal("from-start video accept must not carry an experimental video child")
+	video, ok := getChild(t, contentNodes(t, accept)[0], "video")
+	if !ok {
+		t.Fatal("from-start video accept omitted the callee video marker")
+	}
+	if dec, _ := attrString(video, "dec"); dec != "H264" {
+		t.Errorf("video accept dec = %q, want H264", dec)
+	}
+	if orientation, _ := attrString(video, "device_orientation"); orientation != "0" {
+		t.Errorf("video accept device_orientation = %q, want 0", orientation)
 	}
 }
 

--- a/signaling/video_test.go
+++ b/signaling/video_test.go
@@ -48,51 +48,36 @@ func TestOfferAdvertisesVideo(t *testing.T) {
 	}
 }
 
-// TestAcceptAdvertisesVideo checks the accept carries a <video> child when requested.
-func TestAcceptAdvertisesVideo(t *testing.T) {
+// TestFromStartVideoAcceptUsesTheEstablishedHandshake pins the observed answer shape:
+// the offer marks the call as video, while preaccept/accept keep the same media-selection
+// children as audio. Video state is announced separately after acceptance.
+func TestFromStartVideoAcceptUsesTheEstablishedHandshake(t *testing.T) {
 	peer, creator := peerJID(), creatorJID()
 	accept := BuildAccept(&AcceptParams{
 		CallID: "CID", To: peer, CallCreator: creator,
-		AudioRates: []string{"16000"}, RelayTe: make([]byte, 6), Video: true,
+		AudioRates: []string{"16000"}, RelayTe: make([]byte, 6),
+		Capability: CapabilityOffer, Video: true,
 	})
-	want := []string{"audio", "video", "te", "net", "encopt"}
+	want := []string{"audio", "te", "net", "encopt", "capability"}
 	if got := childTags(t, accept); !eqTags(got, want) {
 		t.Errorf("accept tags = %v, want %v", got, want)
 	}
-	video, ok := getChild(t, contentNodes(t, accept)[0], "video")
-	if !ok {
-		t.Fatal("video accept child missing")
-	}
-	if dec, _ := attrString(video, "dec"); dec != "H264" {
-		t.Errorf("video accept dec = %q, want H264", dec)
-	}
-	if orientation, _ := attrString(video, "device_orientation"); orientation != "0" {
-		t.Errorf("video accept device_orientation = %q, want 0", orientation)
+	if _, ok := getChild(t, contentNodes(t, accept)[0], "video"); ok {
+		t.Fatal("from-start video accept must not carry an experimental video child")
 	}
 }
 
-func TestVideoPreacceptAdvertisesDecoder(t *testing.T) {
+func TestVideoPreacceptUsesPreacceptCapability(t *testing.T) {
 	peer, creator := peerJID(), creatorJID()
 	pre := BuildPreaccept("CID", peer, creator, "wrap", []string{"16000"}, true)
 
-	want := []string{"audio", "video", "encopt", "capability"}
+	want := []string{"audio", "encopt", "capability"}
 	if got := childTags(t, pre); !eqTags(got, want) {
 		t.Errorf("video preaccept tags = %v, want %v", got, want)
 	}
 	action := contentNodes(t, pre)[0]
-	video, ok := getChild(t, action, "video")
-	if !ok {
-		t.Fatal("video preaccept child missing")
-	}
-	for attr, want := range map[string]string{
-		"dec":                "H264",
-		"device_orientation": "0",
-		"screen_width":       "0",
-		"screen_height":      "0",
-	} {
-		if got, _ := attrString(video, attr); got != want {
-			t.Errorf("video preaccept %s = %q, want %q", attr, got, want)
-		}
+	if _, ok := getChild(t, action, "video"); ok {
+		t.Fatal("video preaccept must not carry an experimental video child")
 	}
 	capability, ok := getChild(t, action, "capability")
 	if !ok {
@@ -102,7 +87,7 @@ func TestVideoPreacceptAdvertisesDecoder(t *testing.T) {
 	if !ok {
 		t.Fatalf("video preaccept capability content = %T, want []byte", capability.Content)
 	}
-	wantCapability := []byte{0x01, 0x05, 0xf7, 0x09, 0xe0, 0xbb, 0x13}
+	wantCapability := []byte{0x01, 0x05, 0xf7, 0x09, 0xe4, 0xbb, 0x07}
 	if !bytes.Equal(gotCapability, wantCapability) {
 		t.Errorf("video preaccept capability = %x, want %x", gotCapability, wantCapability)
 	}

--- a/signaling/video_test.go
+++ b/signaling/video_test.go
@@ -50,18 +50,18 @@ func TestOfferAdvertisesVideo(t *testing.T) {
 
 // TestFromStartVideoAcceptMatchesCapturedCalleeShape pins the complete captured answer.
 func TestFromStartVideoAcceptMatchesCapturedCalleeShape(t *testing.T) {
+	// Source of truth: https://github.com/oxidezap/whatsapp-rust/blob/d37b1756d05fb34c9b6c2410c48dd20d27394929/wacore/src/stanza/call.rs#L2119-L2134
 	peer, creator := peerJID(), creatorJID()
 	accept := BuildAccept(&AcceptParams{
 		CallID: "CID", To: peer, WrapperID: "accept-wrap", CallCreator: creator,
-		AudioRates: []string{"16000"}, RelayTe: make([]byte, 6),
-		Capability: CapabilityOffer,
+		AudioRates: []string{"16000"},
 		Metadata: waBinary.Attrs{
 			"peer_abtest_bucket":         "bucket-a",
 			"peer_abtest_bucket_id_list": "11,22",
 		},
 		Video: true,
 	})
-	want := []string{"audio", "video", "te", "net", "encopt", "metadata", "capability"}
+	want := []string{"audio", "video", "net", "encopt", "metadata"}
 	if got := childTags(t, accept); !eqTags(got, want) {
 		t.Errorf("accept tags = %v, want %v", got, want)
 	}
@@ -92,13 +92,11 @@ func TestFromStartVideoAcceptMatchesCapturedCalleeShape(t *testing.T) {
 	if got, _ := attrString(metadata, "peer_abtest_bucket_id_list"); got != "11,22" {
 		t.Errorf("peer_abtest_bucket_id_list = %q, want 11,22", got)
 	}
-	capability, ok := getChild(t, action, "capability")
-	if !ok {
-		t.Fatal("video accept capability missing")
+	if _, ok := getChild(t, action, "te"); ok {
+		t.Fatal("from-start video accept unexpectedly echoed a relay endpoint")
 	}
-	wantCapability := []byte{0x01, 0x05, 0xf7, 0x09, 0xe0, 0xbb, 0x13}
-	if got, ok := capability.Content.([]byte); !ok || !bytes.Equal(got, wantCapability) {
-		t.Errorf("video accept capability = %x, want %x", got, wantCapability)
+	if _, ok := getChild(t, action, "capability"); ok {
+		t.Fatal("from-start video accept unexpectedly advertised a capability")
 	}
 }
 


### PR DESCRIPTION
Makes incoming final accept bounded and idempotent. The existing mute_v2 path remains immediate, while a configurable fallback starts only after relay transport is ready. Includes deterministic fake-clock/fake-sender coverage for voice, video, cancellation, concurrency, late callbacks, and send failure. Validation: go vet ./..., go test ./..., and go test -race ./... with Go 1.26.4.