### PR TITLE
engine.go: select relay-advertised peer device

### DIFF
--- a/engine.go
+++ b/engine.go
@@ -501,6 +501,9 @@ func (e *engine) onOffer(ev *events.CallOffer) {
 	m.remoteVideo = isVideo
 	if r := findRelay(ev.Data); r != nil {
 		m.relay = parseRelayData(r)
+		if !m.relay.peerJID.IsEmpty() {
+			m.peerLID = m.relay.peerJID.String()
+		}
 	}
 	e.applyVoipSettingsCodec(m, ev.Data, ev.CallID)
 	e.mu.Unlock()
@@ -624,14 +627,33 @@ func (e *engine) onRelay(callID string, data *waBinary.Node) {
 	if r == nil {
 		return
 	}
+	rd := parseRelayData(r)
+	var rekeyPeer func(string) error
+	var peerLID string
 	e.mu.Lock()
 	m := e.calls[callID]
 	if m == nil {
 		e.mu.Unlock()
 		return
 	}
-	m.relay = parseRelayData(r)
+	m.relay = rd
+	if !rd.peerJID.IsEmpty() {
+		peerLID = rd.peerJID.String()
+		if peerLID != m.peerLID {
+			m.peerLID = peerLID
+			rekeyPeer = m.rekeyPeer
+		}
+	}
 	e.mu.Unlock()
+	if rekeyPeer != nil {
+		if err := rekeyPeer(peerLID); err != nil {
+			e.c.log.Warn().Err(err).Str("call_id", callID).Str("peer_lid", peerLID).
+				Msg("failed to rekey media to relay-elected peer")
+		} else {
+			e.c.log.Info().Str("call_id", callID).Str("peer_lid", peerLID).
+				Msg("rekeyed media to relay-elected peer")
+		}
+	}
 	e.maybeStartMedia(callID)
 }
 
@@ -713,6 +735,7 @@ func (e *engine) onAccept(ev *events.CallAccept) {
 		e.applyVoipSettingsCodec(current, ev.Data, ev.CallID)
 		if !ev.From.IsEmpty() {
 			current.from = ev.From
+			answeringPeer = preferQualifiedPeer(current.peerLID, ev.From)
 		}
 		if answeringPeer != "" && answeringPeer != current.peerLID {
 			current.peerLID = answeringPeer
@@ -744,6 +767,21 @@ func (e *engine) onAccept(ev *events.CallAccept) {
 		"from": ev.From.String(), "platform": ev.RemotePlatform, "video": m.localVideo || m.remoteVideo,
 	})
 	e.maybeStartMedia(ev.CallID)
+}
+
+func preferQualifiedPeer(current string, signaled types.JID) string {
+	if signaled.IsEmpty() {
+		return current
+	}
+	parsed, err := types.ParseJID(current)
+	if err == nil &&
+		parsed.User == signaled.User &&
+		parsed.Server == signaled.Server &&
+		parsed.Device != 0 &&
+		signaled.Device == 0 {
+		return current
+	}
+	return signaled.String()
 }
 
 // onReject tears down an outgoing call when the peer declines it.
@@ -1198,6 +1236,7 @@ type relayData struct {
 	relayKeyASCII []byte   // raw <key> content — the STUN MESSAGE-INTEGRITY key
 	relayTokens   [][]byte // indexed <token id=…>
 	endpoints     []relayEndpoint
+	peerJID       types.JID
 }
 
 func nodeBytes(n *waBinary.Node) []byte {
@@ -1309,21 +1348,26 @@ func parseRelayData(node *waBinary.Node) *relayData {
 	rd.relayTokens = parseIndexedTokens(node, "token")
 
 	kids := node.GetChildren()
+	peerPID := node.AttrGetter().String("peer_pid")
 	for i := range kids {
-		te2 := &kids[i]
-		if te2.Tag != "te2" {
+		child := &kids[i]
+		if child.Tag == "participant" && peerPID != "" && child.AttrGetter().String("pid") == peerPID {
+			rd.peerJID = child.AttrGetter().JID("jid")
 			continue
 		}
-		ab := nodeBytes(te2)
+		if child.Tag != "te2" {
+			continue
+		}
+		ab := nodeBytes(child)
 		if len(ab) != 6 { // IPv4:port only (IPv6 endpoints skipped)
 			continue
 		}
 		ep := relayEndpoint{
-			relayID:     attrUint(te2, "relay_id"),
-			relayName:   te2.AttrGetter().String("relay_name"),
-			tokenID:     attrUint(te2, "token_id"),
-			authTokenID: attrUint(te2, "auth_token_id"),
-			isFNA:       te2.AttrGetter().String("is_fna") == "1",
+			relayID:     attrUint(child, "relay_id"),
+			relayName:   child.AttrGetter().String("relay_name"),
+			tokenID:     attrUint(child, "token_id"),
+			authTokenID: attrUint(child, "auth_token_id"),
+			isFNA:       child.AttrGetter().String("is_fna") == "1",
 			addresses: []relayAddress{{
 				ipv4: fmt.Sprintf("%d.%d.%d.%d", ab[0], ab[1], ab[2], ab[3]),
 				port: binary.BigEndian.Uint16(ab[4:6]),

--- a/engine_lifecycle_test.go
+++ b/engine_lifecycle_test.go
@@ -373,6 +373,94 @@ func TestOutgoingAcceptRekeysToAnsweringDevice(t *testing.T) {
 	}
 }
 
+func TestParseRelayDataResolvesElectedPeerDevice(t *testing.T) {
+	primary := peerJID()
+	companion := peerJID()
+	companion.Device = 7
+	relay := &waBinary.Node{
+		Tag:   "relay",
+		Attrs: waBinary.Attrs{"peer_pid": "2", "self_pid": "1"},
+		Content: []waBinary.Node{
+			{Tag: "participant", Attrs: waBinary.Attrs{"pid": "0", "jid": primary}},
+			{Tag: "participant", Attrs: waBinary.Attrs{"pid": "2", "jid": companion}},
+		},
+	}
+
+	rd := parseRelayData(relay)
+
+	if rd.peerJID != companion {
+		t.Fatalf("relay peer = %s, want %s", rd.peerJID, companion)
+	}
+}
+
+func TestRelayRekeysToElectedPeerDevice(t *testing.T) {
+	eng, call := testEngineWithOutgoingCall()
+	m := eng.calls[call.ID()]
+	m.peerLID = peerJID().String()
+	companion := peerJID()
+	companion.Device = 7
+	var rekeyed string
+	m.rekeyPeer = func(peer string) error {
+		rekeyed = peer
+		return nil
+	}
+	relay := &waBinary.Node{
+		Tag:   "relay",
+		Attrs: waBinary.Attrs{"peer_pid": "2"},
+		Content: []waBinary.Node{
+			{Tag: "participant", Attrs: waBinary.Attrs{"pid": "2", "jid": companion}},
+		},
+	}
+
+	eng.onRelay(call.ID(), relay)
+
+	if rekeyed != companion.String() {
+		t.Fatalf("rekeyed peer = %q, want %q", rekeyed, companion.String())
+	}
+	eng.mu.Lock()
+	gotPeer := m.peerLID
+	eng.mu.Unlock()
+	if gotPeer != companion.String() {
+		t.Fatalf("stored peer = %q, want %q", gotPeer, companion.String())
+	}
+}
+
+func TestUnqualifiedAcceptPreservesRelayElectedPeerDevice(t *testing.T) {
+	eng, call := testEngineWithOutgoingCall()
+	m := eng.calls[call.ID()]
+	m.peerLID = peerJID().String()
+	companion := peerJID()
+	companion.Device = 7
+	var rekeyed []string
+	m.rekeyPeer = func(peer string) error {
+		rekeyed = append(rekeyed, peer)
+		return nil
+	}
+	relay := &waBinary.Node{
+		Tag:   "relay",
+		Attrs: waBinary.Attrs{"peer_pid": "2"},
+		Content: []waBinary.Node{
+			{Tag: "participant", Attrs: waBinary.Attrs{"pid": "2", "jid": companion}},
+		},
+	}
+	eng.onRelay(call.ID(), relay)
+
+	eng.onAccept(&events.CallAccept{
+		BasicCallMeta: types.BasicCallMeta{CallID: call.ID(), From: peerJID()},
+		Data:          &waBinary.Node{Tag: "accept"},
+	})
+
+	if len(rekeyed) != 1 || rekeyed[0] != companion.String() {
+		t.Fatalf("rekeyed peers = %v, want only %q", rekeyed, companion.String())
+	}
+	eng.mu.Lock()
+	gotPeer := m.peerLID
+	eng.mu.Unlock()
+	if gotPeer != companion.String() {
+		t.Fatalf("stored peer after accept = %q, want %q", gotPeer, companion.String())
+	}
+}
+
 func TestOutgoingPeerAcceptCallbackFiresOnceAfterMediaStarted(t *testing.T) {
 	eng, call := testEngineWithOutgoingCall()
 	call.setPhase(CallPhaseConnecting)


### PR DESCRIPTION
Uses the call relay participant table instead of enumerating possible device indices.

- resolves `peer_pid` to the matching device-qualified `<participant jid>` before media startup
- rekeys through the existing receive-path callback when relay identity arrives late
- keeps the relay-qualified SRTP identity when a later accept only carries a bare routing JID
- covers relay selection, late rekeying, and accept ordering

Validation:
- `go test ./...`
- `go vet ./...`
- `go test -race ./...`