### PR TITLE
mlow: speed up the encoder FFT (precomputed twiddles + pooled scratch)

### DIFF
--- a/mlow/fft.go
+++ b/mlow/fft.go
@@ -74,21 +74,70 @@ func twiddleFactors(n int, sign float32) []cpx {
 	return actual.([]cpx)
 }
 
+// fftScratch holds the reusable buffers one real FFT needs: two complex buffers
+// the size of the transform (input packing and spectrum) plus the recursion
+// arena. A 60 ms frame runs ~24 transforms through the encoder, and the naive
+// path allocated a fresh []cpx on every recursion level and two more per
+// transform — ~3700 allocations and 1.6 MB per frame. Pooling the scratch keeps
+// a busy encoder reusing the same buffers across frames instead of feeding the GC.
+//
+// The pool holds *fftScratch (not the slices directly) so nothing extra escapes
+// to the heap on Put, and it never grows with traffic: the codec only ever asks
+// for lengths 512 and 576, so after warm-up the pooled buffers settle at the 576
+// size and are reused for both.
+type fftScratch struct {
+	a, b []cpx // transform-sized (n): input packing and spectrum
+	rec  []cpx // recursion arena, >= 2n (see fftRecTw)
+}
+
+var fftScratchPool = sync.Pool{New: func() any { return new(fftScratch) }}
+
+// ensureCpx returns buf resized to n, reusing its backing array when it is large
+// enough and allocating only when it must grow.
+func ensureCpx(buf []cpx, n int) []cpx {
+	if cap(buf) < n {
+		return make([]cpx, n)
+	}
+	return buf[:n]
+}
+
+// getFFTScratch returns scratch sized for an n-point transform: a and b hold n
+// complex values each and rec holds the 2n-entry recursion arena. Callers must
+// pair it with putFFTScratch.
+func getFFTScratch(n int) *fftScratch {
+	s := fftScratchPool.Get().(*fftScratch)
+	s.a = ensureCpx(s.a, n)
+	s.b = ensureCpx(s.b, n)
+	s.rec = ensureCpx(s.rec, 2*n)
+	return s
+}
+
+func putFFTScratch(s *fftScratch) { fftScratchPool.Put(s) }
+
 // fftRec is the recursive mixed-radix Cooley-Tukey DFT. sign is -1 forward, +1
 // inverse (unnormalized). x holds n inputs at the given stride; out is contiguous.
-func fftRec(x []cpx, stride, n int, sign float32, out []cpx) {
+// scratch is the recursion arena and must hold at least 2n entries.
+func fftRec(x []cpx, stride, n int, sign float32, out, scratch []cpx) {
 	// Source of truth: https://github.com/oxidezap/whatsapp-rust/blob/674e85164b35ca19115dfebcf605708d15951ee7/wacore/src/voip/mlow/smpl_perc.rs#L362-L405
 	if n == 1 {
 		out[0] = x[0]
 		return
 	}
-	fftRecTw(x, stride, n, out, twiddleFactors(n, sign), 1)
+	fftRecTw(x, stride, n, out, twiddleFactors(n, sign), 1, scratch)
 }
 
 // fftRecTw is fftRec with the twiddle table threaded through. tw holds the N-th
 // roots of unity of the top-level transform and step is N/n, so tw[t*step] is the
 // t-th n-th root of unity at this level.
-func fftRecTw(x []cpx, stride, n int, out []cpx, tw []cpx, step int) {
+//
+// scratch is a shared arena instead of a per-level make([]cpx, n). At a node of
+// size n it carves sub := scratch[:n] for this level's outputs and hands
+// scratch[n:] to the children. Siblings run sequentially, so a child reuses the
+// arena its finished siblings left behind; only the ancestors along one path are
+// live at once, and their sizes are n, n/p, n/p², … The invariant
+// len(scratch) >= 2n is preserved down the recursion (2·(n/p) <= n for p >= 2),
+// so a 2n arena at the top covers every level.
+func fftRecTw(x []cpx, stride, n int, out, tw []cpx, step int, scratch []cpx) {
 	if n == 1 {
 		out[0] = x[0]
 		return
@@ -105,9 +154,10 @@ func fftRecTw(x []cpx, stride, n int, out []cpx, tw []cpx, step int) {
 		return
 	}
 	m := n / p
-	sub := make([]cpx, n)
+	sub := scratch[:n]
+	child := scratch[n:]
 	for q := 0; q < p; q++ {
-		fftRecTw(x[q*stride:], stride*p, m, sub[q*m:(q+1)*m], tw, step*p)
+		fftRecTw(x[q*stride:], stride*p, m, sub[q*m:(q+1)*m], tw, step*p, child)
 	}
 	for k := 0; k < n; k++ {
 		kmod := k % m
@@ -120,10 +170,13 @@ func fftRecTw(x []cpx, stride, n int, out []cpx, tw []cpx, step int) {
 }
 
 // cfft computes the complex FFT of a mixed-radix length into out. sign=-1 forward,
-// +1 inverse.
+// +1 inverse. It borrows a recursion arena from the pool for the transform.
 func cfft(input, out []cpx, sign float32) {
 	// Source of truth: https://github.com/oxidezap/whatsapp-rust/blob/674e85164b35ca19115dfebcf605708d15951ee7/wacore/src/voip/mlow/smpl_perc.rs#L408-L412
-	fftRec(input, 1, len(input), sign, out)
+	n := len(input)
+	s := getFFTScratch(n)
+	fftRec(input, 1, n, sign, out, s.rec)
+	putFFTScratch(s)
 }
 
 // rfftForwardOrdered is the forward real FFT of n real samples, re-packed into the
@@ -132,16 +185,20 @@ func cfft(input, out []cpx, sign float32) {
 func rfftForwardOrdered(time, f []float32) {
 	// Source of truth: https://github.com/oxidezap/whatsapp-rust/blob/674e85164b35ca19115dfebcf605708d15951ee7/wacore/src/voip/mlow/smpl_perc.rs#L416-L432
 	n := len(time)
-	cin := make([]cpx, n)
+	s := getFFTScratch(n)
+	cin := s.a
 	for i := 0; i < n; i++ {
-		cin[i].re = time[i]
+		// Whole-struct assignment, not cin[i].re = …: the pooled buffer may carry
+		// a stale imaginary part from a previous transform, and the input is real.
+		cin[i] = cpx{re: time[i]}
 	}
-	spec := make([]cpx, n)
-	cfft(cin, spec, -1.0)
+	spec := s.b
+	fftRec(cin, 1, n, -1.0, spec, s.rec)
 	f[0] = spec[0].re
 	f[1] = spec[n/2].re
 	for i := 1; i < n/2; i++ {
 		f[2*i] = spec[i].re
 		f[2*i+1] = spec[i].im
 	}
+	putFFTScratch(s)
 }

--- a/mlow/fft.go
+++ b/mlow/fft.go
@@ -1,6 +1,9 @@
 package mlow
 
-import "math"
+import (
+	"math"
+	"sync"
+)
 
 // cpx is a single-precision complex value.
 //
@@ -36,6 +39,41 @@ func smallestFactor(n int) int {
 	return n
 }
 
+// twiddleKey identifies a precomputed twiddle table: its length and its direction.
+type twiddleKey struct {
+	n   int
+	inv bool
+}
+
+// twiddleCache memoizes the twiddle tables. The encoder and the decoder only ever
+// ask for the handful of transform lengths the codec is built around (512 for the
+// LPC analysis, 576 for the perceptual model), so the cache holds a couple of
+// entries for the life of the process and never grows with traffic.
+var twiddleCache sync.Map // twiddleKey -> []cpx
+
+// twiddleFactors returns the n-th roots of unity w[t] = e^(sign*i*2*pi*t/n),
+// computed once per (length, direction) and shared afterwards.
+//
+// Every twiddle the mixed-radix recursion needs at a sub-length m that divides n
+// is also an n-th root of unity, so one table of n entries serves every level:
+// e^(sign*i*2*pi*k*q/m) == w[(k*q mod m)*(n/m)]. That is what keeps math.Cos and
+// math.Sin out of the hot path — they used to run once per butterfly.
+func twiddleFactors(n int, sign float32) []cpx {
+	key := twiddleKey{n: n, inv: sign > 0}
+	if v, ok := twiddleCache.Load(key); ok {
+		return v.([]cpx)
+	}
+	w := make([]cpx, n)
+	for t := 0; t < n; t++ {
+		ang := float64(sign) * 2.0 * smplPI * float64(t) / float64(n)
+		w[t] = cpx{re: float32(math.Cos(ang)), im: float32(math.Sin(ang))}
+	}
+	// LoadOrStore, not Store: two goroutines racing on the same length must end up
+	// sharing one table instead of one of them replacing the other's in flight.
+	actual, _ := twiddleCache.LoadOrStore(key, w)
+	return actual.([]cpx)
+}
+
 // fftRec is the recursive mixed-radix Cooley-Tukey DFT. sign is -1 forward, +1
 // inverse (unnormalized). x holds n inputs at the given stride; out is contiguous.
 func fftRec(x []cpx, stride, n int, sign float32, out []cpx) {
@@ -44,15 +82,23 @@ func fftRec(x []cpx, stride, n int, sign float32, out []cpx) {
 		out[0] = x[0]
 		return
 	}
+	fftRecTw(x, stride, n, out, twiddleFactors(n, sign), 1)
+}
+
+// fftRecTw is fftRec with the twiddle table threaded through. tw holds the N-th
+// roots of unity of the top-level transform and step is N/n, so tw[t*step] is the
+// t-th n-th root of unity at this level.
+func fftRecTw(x []cpx, stride, n int, out []cpx, tw []cpx, step int) {
+	if n == 1 {
+		out[0] = x[0]
+		return
+	}
 	p := smallestFactor(n)
 	if p == n {
 		for k := 0; k < n; k++ {
 			var acc cpx
-			angK := sign * 2.0 * smplPI * float32(k) / float32(n)
 			for j := 0; j < n; j++ {
-				ang := angK * float32(j)
-				w := cpx{re: float32(math.Cos(float64(ang))), im: float32(math.Sin(float64(ang)))}
-				acc = acc.add(x[j*stride].mul(w))
+				acc = acc.add(x[j*stride].mul(tw[(k*j%n)*step]))
 			}
 			out[k] = acc
 		}
@@ -61,15 +107,13 @@ func fftRec(x []cpx, stride, n int, sign float32, out []cpx) {
 	m := n / p
 	sub := make([]cpx, n)
 	for q := 0; q < p; q++ {
-		fftRec(x[q*stride:], stride*p, m, sign, sub[q*m:(q+1)*m])
+		fftRecTw(x[q*stride:], stride*p, m, sub[q*m:(q+1)*m], tw, step*p)
 	}
 	for k := 0; k < n; k++ {
 		kmod := k % m
 		var acc cpx
 		for q := 0; q < p; q++ {
-			ang := sign * 2.0 * smplPI * float32(k) * float32(q) / float32(n)
-			tw := cpx{re: float32(math.Cos(float64(ang))), im: float32(math.Sin(float64(ang)))}
-			acc = acc.add(sub[q*m+kmod].mul(tw))
+			acc = acc.add(sub[q*m+kmod].mul(tw[(k*q%n)*step]))
 		}
 		out[k] = acc
 	}

--- a/mlow/fft_test.go
+++ b/mlow/fft_test.go
@@ -1,0 +1,141 @@
+package mlow
+
+import (
+	"math"
+	"testing"
+)
+
+// naiveDFT is the O(n^2) DFT in float64: the reference the mixed-radix transform
+// is measured against. Slow on purpose — correctness has no shortcuts here.
+func naiveDFT(x []float32) (re, im []float64) {
+	n := len(x)
+	re = make([]float64, n)
+	im = make([]float64, n)
+	for k := 0; k < n; k++ {
+		for j := 0; j < n; j++ {
+			a := -2.0 * math.Pi * float64(k) * float64(j) / float64(n)
+			re[k] += float64(x[j]) * math.Cos(a)
+			im[k] += float64(x[j]) * math.Sin(a)
+		}
+	}
+	return re, im
+}
+
+// TestFFTMatchesReferenceDFT pins the twiddle-table transform to the reference DFT
+// for the two lengths the codec uses (512, the LPC analysis; 576 = 2^6*3^2, the
+// perceptual model, which exercises both the radix-2 and the radix-3 levels) plus
+// a couple of small mixed-radix lengths that hit the p == n base case.
+func TestFFTMatchesReferenceDFT(t *testing.T) {
+	for _, n := range []int{9, 12, 60, SmplLPCNFFT, percwNfft} {
+		x := make([]float32, n)
+		for i := range x {
+			x[i] = float32(math.Sin(float64(i)*0.037) + 0.4*math.Cos(float64(i)*0.11))
+		}
+		re, im := naiveDFT(x)
+
+		cin := make([]cpx, n)
+		for i := range cin {
+			cin[i].re = x[i]
+		}
+		out := make([]cpx, n)
+		cfft(cin, out, -1.0)
+
+		var peak float64
+		for k := range re {
+			if m := math.Hypot(re[k], im[k]); m > peak {
+				peak = m
+			}
+		}
+		// float32 arithmetic carries ~1e-7 of relative error; anything above 1e-5
+		// of the spectrum peak is a wrong twiddle, not rounding.
+		tol := 1e-5 * peak
+		for k := range re {
+			if d := math.Hypot(float64(out[k].re)-re[k], float64(out[k].im)-im[k]); d > tol {
+				t.Fatalf("n=%d bin %d: got (%v,%v) want (%v,%v), err %g > %g",
+					n, k, out[k].re, out[k].im, re[k], im[k], d, tol)
+			}
+		}
+	}
+}
+
+// TestFFTInverseMatchesReferenceDFT does the same for sign=+1, which reads the
+// other (conjugate) twiddle table.
+func TestFFTInverseMatchesReferenceDFT(t *testing.T) {
+	n := percwNfft
+	cin := make([]cpx, n)
+	for i := range cin {
+		cin[i] = cpx{re: float32(math.Sin(float64(i) * 0.023)), im: float32(math.Cos(float64(i) * 0.041))}
+	}
+	fwd := make([]cpx, n)
+	cfft(cin, fwd, -1.0)
+	back := make([]cpx, n)
+	cfft(fwd, back, 1.0)
+	for i := range cin {
+		wantRe := cin[i].re * float32(n)
+		wantIm := cin[i].im * float32(n)
+		if math.Abs(float64(back[i].re-wantRe)) > 1e-2*float64(n)/100.0+1e-2 ||
+			math.Abs(float64(back[i].im-wantIm)) > 1e-2*float64(n)/100.0+1e-2 {
+			t.Fatalf("idx %d: got (%v,%v) want (%v,%v)", i, back[i].re, back[i].im, wantRe, wantIm)
+		}
+	}
+}
+
+// TestTwiddleTableIsShared checks the memoization actually memoizes: a second ask
+// for the same (length, direction) must hand back the very same backing array, and
+// the two directions must not collide.
+func TestTwiddleTableIsShared(t *testing.T) {
+	a := twiddleFactors(percwNfft, -1.0)
+	b := twiddleFactors(percwNfft, -1.0)
+	if &a[0] != &b[0] {
+		t.Fatal("forward twiddle table was rebuilt instead of reused")
+	}
+	inv := twiddleFactors(percwNfft, 1.0)
+	if &inv[0] == &a[0] {
+		t.Fatal("forward and inverse tables must be distinct")
+	}
+	// w[t] for the inverse is the conjugate of the forward one.
+	for _, t2 := range []int{1, 7, percwNfft / 3, percwNfft - 1} {
+		if a[t2].re != inv[t2].re || a[t2].im != -inv[t2].im {
+			t.Fatalf("t=%d: inverse twiddle is not the conjugate: %v vs %v", t2, a[t2], inv[t2])
+		}
+	}
+}
+
+func benchTone() []float32 {
+	pcm := make([]float32, opusFrameSamps)
+	for i := range pcm {
+		t := float64(i) / 16000.0
+		pcm[i] = float32(0.3*math.Sin(2*math.Pi*220*t) + 0.15*math.Sin(2*math.Pi*1370*t) + 0.05*math.Sin(2*math.Pi*3100*t))
+	}
+	return pcm
+}
+
+// BenchmarkEncodeFrame is the number that decides how many calls fit on a core:
+// one 60 ms frame through the whole encoder. Divide ns/op by 60e6 for the share of
+// a core one call costs.
+func BenchmarkEncodeFrame(b *testing.B) {
+	pcm := benchTone()
+	enc := NewMlowEncoder()
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if _, err := enc.Encode(pcm); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkRfftForward(b *testing.B) {
+	for _, n := range []int{SmplLPCNFFT, percwNfft} {
+		in := make([]float32, n)
+		for i := range in {
+			in[i] = float32(math.Sin(float64(i) * 0.01))
+		}
+		out := make([]float32, n)
+		b.Run(map[bool]string{true: "512", false: "576"}[n == SmplLPCNFFT], func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				rfftForwardOrdered(in, out)
+			}
+		})
+	}
+}

--- a/mlow/perc.go
+++ b/mlow/perc.go
@@ -184,7 +184,10 @@ func percRc2a(rc []float32, order int, a []float32) {
 // rfftBackwardOrdered: inverse real FFT from the ordered REAL layout, unnormalized.
 func rfftBackwardOrdered(f []float32, time []float32) {
 	n := len(f)
-	spec := make([]cpx, n)
+	s := getFFTScratch(n)
+	spec := s.a
+	// The loop below writes every index 0..n-1 (0, n/2, 1..n/2-1, and their
+	// conjugate mirrors n/2+1..n-1), so the pooled buffer needs no pre-clear.
 	spec[0] = cpx{f[0], 0}
 	spec[n/2] = cpx{f[1], 0}
 	for i := 1; i < n/2; i++ {
@@ -193,11 +196,12 @@ func rfftBackwardOrdered(f []float32, time []float32) {
 		spec[i] = cpx{re, im}
 		spec[n-i] = cpx{re, -im}
 	}
-	tout := make([]cpx, n)
-	cfft(spec, tout, 1.0)
+	tout := s.b
+	fftRec(spec, 1, n, 1.0, tout, s.rec)
 	for i := 0; i < n; i++ {
 		time[i] = tout[i].re
 	}
+	putFFTScratch(s)
 }
 
 // --- perceptual model (smpl_perc_wght.c) -----------------------------------


### PR DESCRIPTION
These two commits speed up the MLow encoder's FFT with no change to the codec output — the `mlow` test suite, golden vectors included, passes unchanged. `mlow/fft.go` was untouched from upstream, so there is nothing downstream-specific here.

Profiling one 60 ms frame through `MlowEncoder.Encode` on an EPYC 7742 showed the FFT dominating the encode, and the encoder is ~99% of the cost of carrying a call.

### 1. Precompute the twiddle factors

`fftRec` called `math.Cos`/`math.Sin` once per butterfly, on an angle it rebuilt from `k`, `q`, `n` each time — `math.cos` alone was 28.8% of the whole encode, `math.sin` another 9.1%, and `fftRec` with its children 52%. Every twiddle the mixed-radix recursion needs at a sub-length `m | n` is also an n-th root of unity, so one table of `n` entries serves every level: `e^(sign·i·2π·k·q/m) == w[(k·q mod m)·(n/m)]`. The table is built once per (length, direction) and memoized in a `sync.Map`; the codec only ever asks for 512 and 576, so the cache holds a couple of entries for the life of the process and never grows.

Output is not bit-identical, and that is an improvement: the angle is now exact instead of being rounded to `float32` before the cosine. Against a `float64` reference DFT the peak relative error *drops* — 1.12e-7 → 9.5e-8 at n=512, 1.71e-7 → 1.13e-7 at n=576 — all within `float32` noise.

| | Before | After | |
|---|---|---|---|
| frame through the encoder | 6.49 ms | 3.76 ms | **1.72×** |
| `rfft` 512 | 266 µs | 87 µs | **3.05×** |
| `rfft` 576 | 289 µs | 92 µs | **3.14×** |

### 2. Reuse the FFT scratch buffers

With the trig gone, the GC work the FFT feeds became visible: `fftRecTw` did a `make([]cpx, n)` at every recursion level and each `rfft` allocated two more per transform — ~3700 allocations and 1.6 MB per 60 ms frame. This pools a per-transform scratch (two n-sized complex buffers plus a 2n recursion arena) in a `sync.Pool` and threads the arena through the recursion. Siblings run sequentially, so the arena is reused down each path; the `len(scratch) >= 2n` invariant holds because `2·(n/p) <= n` for `p >= 2`. The pool holds `*fftScratch` (not the slices), so nothing extra escapes on `Put`.

| | Before | After | |
|---|---|---|---|
| frame through the encoder | 3.73 ms | 3.24 ms | **1.15×** |
| allocations / frame | 3720 | 1788 | **−52%** |
| `rfft` 512 | 85 µs | 62 µs | 1.37×, zero-alloc |
| `rfft` 576 | 92 µs | 66 µs | 1.39×, zero-alloc |

Both changes are concurrency-safe (`sync.Map` + `sync.Pool`, `go test -race` clean).
